### PR TITLE
[Feat]: add recipe view count

### DIFF
--- a/api/api.webpack.config.js
+++ b/api/api.webpack.config.js
@@ -11,6 +11,7 @@ module.exports = (options, webpack) => {
 
   return {
     ...options,
+    devtool: 'source-map',
     externals: [
       {
         kafkajs: 'commonjs kafkajs',
@@ -26,6 +27,7 @@ module.exports = (options, webpack) => {
     output: {
       ...options.output,
       libraryTarget: 'commonjs2',
+      devtoolModuleFilenameTemplate: 'file:///[absolute-resource-path]',
     },
     optimization: {
       minimizer: [

--- a/api/libs/common/src/cache/memory-cache.service.ts
+++ b/api/libs/common/src/cache/memory-cache.service.ts
@@ -1,0 +1,36 @@
+import { Inject } from '@nestjs/common';
+import { MEMORY_CACHE } from './cache.constant';
+import { Cache } from 'cache-manager';
+import {
+  Aspect,
+  LazyDecorator,
+  WrapParams,
+  createDecorator,
+} from '@toss/nestjs-aop';
+
+/**
+ * @ttl time to live in milliseconds
+ */
+export type CacheOption = {
+  ttl: number;
+  generateKey: (...args: any[]) => string;
+};
+
+export const Cacheable = (option: CacheOption) =>
+  createDecorator(MEMORY_CACHE, option);
+
+@Aspect(MEMORY_CACHE)
+export class MemoryCacheService implements LazyDecorator<any, CacheOption> {
+  constructor(@Inject(MEMORY_CACHE) private readonly cacheManager: Cache) {}
+
+  wrap({ method, metadata }: WrapParams<any, CacheOption>) {
+    return async (...args: any[]) => {
+      const key = metadata.generateKey(...args);
+      const cached = await this.cacheManager.get(key);
+      if (cached) return cached;
+      const ret = await method(...args);
+      await this.cacheManager.set(key, ret, metadata.ttl);
+      return ret;
+    };
+  }
+}

--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -18,7 +18,7 @@ import {
   Patch,
   Post,
   Query,
-  ValidationPipe,
+  Ip,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { CreateRecipeDto, UpdateRecipeDto } from '../dto/modify-recipe.dto';
@@ -31,6 +31,7 @@ import {
 import { RecipeService } from '../services/recipe.service';
 import { Logable } from '@app/common/log/log.decorator';
 import { FilterRecipeDto, TextSearchRecipeDto } from '../dto/filter-recipe.dto';
+import { RecipeViewerIdentifier } from '../dto/recipe-viewer-identifier';
 
 @ApiTags('Recipe')
 @Controller('recipe')
@@ -97,8 +98,16 @@ export class RecipeController {
   // @Auth()
   @ApiGet(FindOneRecipeResponseDto)
   @Get(':id')
-  async findOne(@Param('id') id: string) {
-    return this.recipeService.findOne(id);
+  async findOne(
+    @Param('id') id: string,
+    @Ip() ip: string,
+    @ReqUser() user: User,
+  ) {
+    await this.recipeService.increaseViewCount(
+      id,
+      new RecipeViewerIdentifier(user, ip),
+    );
+    return await this.recipeService.findOne(id);
   }
 
   /**

--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -26,6 +26,7 @@ import {
   CreateRecipeResponseDto,
   FindOneRecipeResponseDto,
   FindRecipesResponseDto,
+  FindTopViewdResponseDto,
   UpdateRecipeResponseDto,
 } from '../dto/recipe-response.dto';
 import { RecipeService } from '../services/recipe.service';
@@ -88,6 +89,12 @@ export class RecipeController {
   ) {
     console.log(textSearchRecipeDto);
     return this.recipeService.findAllByFullTextSearch(textSearchRecipeDto);
+  }
+
+  @ApiGet(FindTopViewdResponseDto)
+  @Get('top-viewed')
+  async findTopViewed() {
+    return this.recipeService.findTopViewed();
   }
 
   /**

--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -135,6 +135,6 @@ export class RecipeController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @Delete(':id')
   async delete(@Param('id') id: string) {
-    return this.recipeService.delete(id);
+    return this.recipeService.deleteOne(id);
   }
 }

--- a/api/libs/recipe/src/dto/filter-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/filter-recipe.dto.ts
@@ -10,6 +10,7 @@ import {
   IsString,
 } from 'class-validator';
 import { Recipe } from '../entities/recipe.entity';
+import { OmitType } from '@nestjs/swagger';
 
 export class FilterRecipeDto extends PagenationDto {
   constructor(
@@ -77,15 +78,22 @@ export class TextSearchRecipeDto extends PagenationDto {
   sort?: TextSearchSortBy;
 }
 
+export class RecipeListViewResponseDto extends OmitType(Recipe, [
+  'recipe_raw_text',
+  'origin_url',
+  'recipe_steps',
+  'ingredient_requirements',
+] as const) {}
+
 export class RecipesResponseDto extends PagenationResponseDto {
-  results: Recipe[];
+  results: RecipeListViewResponseDto[];
 }
 
 export class RecipesAndCountDto {
-  recipes: Recipe[];
+  recipes: RecipeListViewResponseDto[];
   count: number;
 
-  constructor(recipes: Recipe[], count: number) {
+  constructor(recipes: RecipeListViewResponseDto[], count: number) {
     this.recipes = recipes;
     this.count = count;
   }

--- a/api/libs/recipe/src/dto/filter-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/filter-recipe.dto.ts
@@ -84,4 +84,18 @@ export class RecipesResponseDto extends PagenationResponseDto {
 export class RecipesAndCountDto {
   recipes: Recipe[];
   count: number;
+
+  constructor(recipes: Recipe[], count: number) {
+    this.recipes = recipes;
+    this.count = count;
+  }
+
+  toRecipesResponseDto(page: number, limit: number): RecipesResponseDto {
+    return {
+      results: this.recipes,
+      page,
+      count: this.recipes.length,
+      has_next: this.count > (page - 1) * limit + this.recipes.length,
+    } as RecipesResponseDto;
+  }
 }

--- a/api/libs/recipe/src/dto/modify-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/modify-recipe.dto.ts
@@ -4,6 +4,7 @@ import {
   IsArray,
   IsMongoId,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
   IsUrl,
@@ -135,4 +136,7 @@ export class CreateRecipeDto {
 
 export class UpdateRecipeDto extends PartialType(
   OmitType(CreateRecipeDto, ['owner'] as const),
-) {}
+) {
+  @IsNumber()
+  view_count: number;
+}

--- a/api/libs/recipe/src/dto/recipe-response.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-response.dto.ts
@@ -3,7 +3,10 @@ import {
   OkResponse,
 } from '@app/common/dto/success-response.dto';
 import { Recipe } from '../entities/recipe.entity';
-import { RecipesResponseDto } from './filter-recipe.dto';
+import {
+  RecipeListViewResponseDto,
+  RecipesResponseDto,
+} from './filter-recipe.dto';
 
 export class CreateRecipeResponseDto extends CreatedResponse {
   data: Recipe;
@@ -11,6 +14,10 @@ export class CreateRecipeResponseDto extends CreatedResponse {
 
 export class FindRecipesResponseDto extends OkResponse {
   data: RecipesResponseDto;
+}
+
+export class FindTopViewdResponseDto extends OkResponse {
+  data: RecipeListViewResponseDto[];
 }
 
 export class FindOneRecipeResponseDto extends OkResponse {

--- a/api/libs/recipe/src/dto/recipe-viewer-identifier.ts
+++ b/api/libs/recipe/src/dto/recipe-viewer-identifier.ts
@@ -1,0 +1,15 @@
+import { User } from '@app/user/entities/user.entity';
+import { IsIP, IsInstance } from 'class-validator';
+
+export class RecipeViewerIdentifier {
+  constructor(user: User, ip: string) {
+    this.user = user;
+    this.ip = ip;
+  }
+
+  @IsInstance(User)
+  user: User;
+
+  @IsIP()
+  ip: string;
+}

--- a/api/libs/recipe/src/entities/recipe.entity.ts
+++ b/api/libs/recipe/src/entities/recipe.entity.ts
@@ -54,6 +54,9 @@ export class Recipe {
   @Prop({ required: true })
   origin_url: string;
 
+  @Prop({ required: true, default: 0 })
+  view_count: number;
+
   @Prop({ required: false })
   created_at: Date;
 

--- a/api/libs/recipe/src/repositories/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe.repository.ts
@@ -113,7 +113,21 @@ export class RecipeRepository {
   }
 
   async findOne(id: string): Promise<Recipe> {
-    return await this.recipeModel.findOne({ id }).exec();
+    return await this.recipeModel
+      .findOne({ id })
+      .select({
+        _id: 0,
+        __v: 0,
+        recipe_raw_text: 0,
+        origin_url: 0,
+      })
+      .exec();
+  }
+
+  async increaseViewCount(id: string): Promise<Recipe> {
+    return await this.recipeModel
+      .findOneAndUpdate({ id }, { $inc: { view_count: 1 } }, { new: true })
+      .exec();
   }
 
   async update(id: string, updateRecipeDto: UpdateRecipeDto): Promise<Recipe> {

--- a/api/libs/recipe/src/repositories/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe.repository.ts
@@ -55,10 +55,7 @@ export class RecipeRepository {
       recipeAggrPipe.exec(),
       countPromise.exec(),
     ]);
-    return {
-      recipes,
-      count: count[0].count,
-    };
+    return new RecipesAndCountDto(recipes, count[0].count);
   }
 
   async findAllByFullTextSearch(
@@ -106,10 +103,7 @@ export class RecipeRepository {
       countPromise.exec(),
     ]);
 
-    return {
-      recipes,
-      count: count[0].count,
-    };
+    return new RecipesAndCountDto(recipes, count[0].count);
   }
 
   async findOne(id: string): Promise<Recipe> {

--- a/api/libs/recipe/src/repositories/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe.repository.ts
@@ -3,6 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import {
   FilterRecipeDto,
+  RecipeListViewResponseDto,
   RecipesAndCountDto,
   TextSearchRecipeDto,
   TextSearchSortBy,
@@ -41,6 +42,8 @@ export class RecipeRepository {
         __v: 0,
         recipe_raw_text: 0,
         origin_url: 0,
+        recipe_steps: 0,
+        ingredient_requirements: 0,
       })
       .pipeline();
     const countPromise = this.recipeModel
@@ -80,6 +83,8 @@ export class RecipeRepository {
         __v: 0,
         recipe_raw_text: 0,
         origin_url: 0,
+        recipe_steps: 0,
+        ingredient_requirements: 0,
       })
       .pipeline();
     const countPromise = this.recipeModel.aggregate(aggrpipe).count('count');
@@ -114,6 +119,22 @@ export class RecipeRepository {
         __v: 0,
         recipe_raw_text: 0,
         origin_url: 0,
+      })
+      .exec();
+  }
+
+  async findTopViewed(): Promise<RecipeListViewResponseDto[]> {
+    return await this.recipeModel
+      .find()
+      .sort({ view_count: -1 })
+      .limit(10)
+      .select({
+        _id: 0,
+        __v: 0,
+        recipe_raw_text: 0,
+        origin_url: 0,
+        recipe_steps: 0,
+        ingredient_requirements: 0,
       })
       .exec();
   }

--- a/api/libs/recipe/src/services/recipe.service.spec.ts
+++ b/api/libs/recipe/src/services/recipe.service.spec.ts
@@ -1,4 +1,11 @@
-import { CreateRecipeDto } from '../dto/modify-recipe.dto';
+import { User } from '@app/user/entities/user.entity';
+import {
+  FilterRecipeDto,
+  RecipesAndCountDto,
+  RecipesResponseDto,
+  TextSearchRecipeDto,
+} from '../dto/filter-recipe.dto';
+import { CreateRecipeDto, UpdateRecipeDto } from '../dto/modify-recipe.dto';
 import { Recipe } from '../entities/recipe.entity';
 import { RecipeRepository } from '../repositories/recipe.repository';
 import { RecipeService } from './recipe.service';
@@ -7,6 +14,38 @@ import { TestBed } from '@automock/jest';
 describe('RecipeService', () => {
   let service: RecipeService;
   let recipeRepository: jest.Mocked<RecipeRepository>;
+
+  const filterRecipeDto: FilterRecipeDto = {
+    page: 1,
+    limit: 2,
+  };
+  const textSearchRecipeDto: TextSearchRecipeDto = {
+    searchQuery: 'test',
+    page: 1,
+    limit: 10,
+  };
+  const recipesAndCountLast: jest.Mocked<RecipesAndCountDto> = {
+    recipes: [new Recipe(), new Recipe()],
+    count: 2,
+    toRecipesResponseDto: jest.fn(),
+  };
+  const recipesAndCountNotLast: jest.Mocked<RecipesAndCountDto> = {
+    recipes: [new Recipe(), new Recipe()],
+    count: 15,
+    toRecipesResponseDto: jest.fn(),
+  };
+  const recipesResponseDtoLast: RecipesResponseDto = {
+    results: recipesAndCountLast.recipes,
+    page: 1,
+    count: 2,
+    has_next: true,
+  };
+  const recipesResponseDtoNotLast: RecipesResponseDto = {
+    results: recipesAndCountNotLast.recipes,
+    page: 1,
+    count: 2,
+    has_next: false,
+  };
 
   beforeEach(async () => {
     const { unit, unitRef } = TestBed.create(RecipeService).compile();
@@ -29,6 +68,180 @@ describe('RecipeService', () => {
 
       expect(recipeRepository.create).toHaveBeenCalledWith(createRecipeDto);
       expect(result).toEqual(recipe);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of recipes with last elements', async () => {
+      recipeRepository.findAll.mockResolvedValue(recipesAndCountLast);
+      recipesAndCountLast.toRecipesResponseDto.mockReturnValue(
+        recipesResponseDtoLast,
+      );
+
+      const result = await service.findAll(filterRecipeDto);
+
+      expect(recipeRepository.findAll).toHaveBeenCalledWith(filterRecipeDto);
+      expect(recipesAndCountLast.toRecipesResponseDto).toHaveBeenCalledWith(
+        filterRecipeDto.page,
+        filterRecipeDto.limit,
+      );
+      expect(result).toEqual(recipesResponseDtoLast);
+    });
+
+    it('should return an array of recipes with not finished', async () => {
+      recipeRepository.findAll.mockResolvedValue(recipesAndCountNotLast);
+      recipesAndCountNotLast.toRecipesResponseDto.mockReturnValue(
+        recipesResponseDtoNotLast,
+      );
+
+      const result = await service.findAll(filterRecipeDto);
+
+      expect(recipeRepository.findAll).toHaveBeenCalledWith(filterRecipeDto);
+      expect(recipesAndCountNotLast.toRecipesResponseDto).toHaveBeenCalledWith(
+        filterRecipeDto.page,
+        filterRecipeDto.limit,
+      );
+      expect(result).toEqual(recipesResponseDtoNotLast);
+    });
+  });
+
+  describe('findAllByFullTextSearch', () => {
+    it('should return an array of recipes without search query', async () => {
+      recipeRepository.findAll.mockResolvedValue(recipesAndCountLast);
+      recipesAndCountLast.toRecipesResponseDto.mockReturnValue(
+        recipesResponseDtoLast,
+      );
+
+      const result = await service.findAllByFullTextSearch(filterRecipeDto);
+
+      expect(recipeRepository.findAll).toHaveBeenCalledWith(filterRecipeDto);
+      expect(recipeRepository.findAllByFullTextSearch).not.toHaveBeenCalled();
+      expect(recipesAndCountLast.toRecipesResponseDto).toHaveBeenCalledWith(
+        filterRecipeDto.page,
+        filterRecipeDto.limit,
+      );
+      expect(result).toEqual(recipesResponseDtoLast);
+    });
+
+    it('should return an last elements array of recipes with search query', async () => {
+      recipeRepository.findAll.mockResolvedValue(recipesAndCountLast);
+      recipesAndCountLast.toRecipesResponseDto.mockReturnValue(
+        recipesResponseDtoLast,
+      );
+      recipeRepository.findAllByFullTextSearch.mockResolvedValue(
+        recipesAndCountLast,
+      );
+
+      const result = await service.findAllByFullTextSearch(textSearchRecipeDto);
+
+      expect(recipeRepository.findAllByFullTextSearch).toHaveBeenCalledWith(
+        textSearchRecipeDto,
+      );
+      expect(recipeRepository.findAll).not.toHaveBeenCalled();
+      expect(recipesAndCountLast.toRecipesResponseDto).toHaveBeenCalledWith(
+        textSearchRecipeDto.page,
+        textSearchRecipeDto.limit,
+      );
+      expect(result).toEqual(recipesResponseDtoLast);
+    });
+
+    it('should return an middle elements array of recipes with search query', async () => {
+      recipeRepository.findAll.mockResolvedValue(recipesAndCountNotLast);
+      recipesAndCountNotLast.toRecipesResponseDto.mockReturnValue(
+        recipesResponseDtoNotLast,
+      );
+      recipeRepository.findAllByFullTextSearch.mockResolvedValue(
+        recipesAndCountNotLast,
+      );
+
+      const result = await service.findAllByFullTextSearch(textSearchRecipeDto);
+
+      expect(recipeRepository.findAllByFullTextSearch).toHaveBeenCalledWith(
+        textSearchRecipeDto,
+      );
+      expect(recipeRepository.findAll).not.toHaveBeenCalled();
+      expect(recipesAndCountNotLast.toRecipesResponseDto).toHaveBeenCalledWith(
+        textSearchRecipeDto.page,
+        textSearchRecipeDto.limit,
+      );
+      expect(result).toEqual(recipesResponseDtoNotLast);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a recipe', async () => {
+      const recipe = new Recipe();
+      recipeRepository.findOne.mockResolvedValue(recipe);
+
+      const result = await service.findOne('1');
+
+      expect(recipeRepository.findOne).toHaveBeenCalledWith('1');
+      expect(result).toEqual(recipe);
+    });
+  });
+
+  describe('increaseViewCount', () => {
+    it('should return true', async () => {
+      recipeRepository.increaseViewCount.mockResolvedValue(new Recipe());
+
+      const result = await service.increaseViewCount('1', {
+        ip: '::1',
+        user: new User(),
+      });
+
+      expect(recipeRepository.increaseViewCount).toHaveBeenCalledWith('1');
+      expect(result).toEqual(true);
+    });
+
+    it('should throw NotFoundException', async () => {
+      recipeRepository.increaseViewCount.mockResolvedValue(null);
+
+      await expect(
+        service.increaseViewCount('1', {
+          ip: '::1',
+          user: new User(),
+        }),
+      ).rejects.toThrowError('Recipe not found');
+    });
+  });
+
+  describe('update', () => {
+    it('should update well', async () => {
+      const recipe = new Recipe();
+      recipeRepository.update.mockResolvedValue(recipe);
+
+      const result = await service.update('1', {} as UpdateRecipeDto);
+
+      expect(recipeRepository.update).toHaveBeenCalledWith('1', {});
+      expect(result).toEqual(recipe);
+    });
+
+    it('should throw NotFoundException', async () => {
+      recipeRepository.update.mockResolvedValue(null);
+
+      await expect(
+        service.update('1', {} as UpdateRecipeDto),
+      ).rejects.toThrowError('Recipe not found');
+    });
+  });
+
+  describe('deleteOne', () => {
+    it('should delete well', async () => {
+      const recipe = new Recipe();
+      recipeRepository.deleteOne.mockResolvedValue(recipe);
+
+      const result = await service.deleteOne('1');
+
+      expect(recipeRepository.deleteOne).toHaveBeenCalledWith('1');
+      expect(result).toEqual(recipe);
+    });
+
+    it('should throw NotFoundException', async () => {
+      recipeRepository.deleteOne.mockResolvedValue(null);
+
+      await expect(service.deleteOne('1')).rejects.toThrowError(
+        'Recipe not found',
+      );
     });
   });
 });

--- a/api/libs/recipe/src/services/recipe.service.spec.ts
+++ b/api/libs/recipe/src/services/recipe.service.spec.ts
@@ -1,6 +1,7 @@
 import { User } from '@app/user/entities/user.entity';
 import {
   FilterRecipeDto,
+  RecipeListViewResponseDto,
   RecipesAndCountDto,
   RecipesResponseDto,
   TextSearchRecipeDto,
@@ -25,12 +26,12 @@ describe('RecipeService', () => {
     limit: 10,
   };
   const recipesAndCountLast: jest.Mocked<RecipesAndCountDto> = {
-    recipes: [new Recipe(), new Recipe()],
+    recipes: [new RecipeListViewResponseDto(), new RecipeListViewResponseDto()],
     count: 2,
     toRecipesResponseDto: jest.fn(),
   };
   const recipesAndCountNotLast: jest.Mocked<RecipesAndCountDto> = {
-    recipes: [new Recipe(), new Recipe()],
+    recipes: [new RecipeListViewResponseDto(), new RecipeListViewResponseDto()],
     count: 15,
     toRecipesResponseDto: jest.fn(),
   };
@@ -177,6 +178,18 @@ describe('RecipeService', () => {
 
       expect(recipeRepository.findOne).toHaveBeenCalledWith('1');
       expect(result).toEqual(recipe);
+    });
+  });
+
+  describe('findTopViewed', () => {
+    it('should return an array of recipes', async () => {
+      const recipe = new RecipeListViewResponseDto();
+      recipeRepository.findTopViewed.mockResolvedValue([recipe]);
+
+      const result = await service.findTopViewed();
+
+      expect(recipeRepository.findTopViewed).toHaveBeenCalled();
+      expect(result).toEqual([recipe]);
     });
   });
 

--- a/api/libs/recipe/src/services/recipe.service.ts
+++ b/api/libs/recipe/src/services/recipe.service.ts
@@ -1,6 +1,7 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import {
   FilterRecipeDto,
+  RecipeListViewResponseDto,
   RecipesAndCountDto,
   RecipesResponseDto,
   TextSearchRecipeDto,
@@ -9,16 +10,11 @@ import { CreateRecipeDto, UpdateRecipeDto } from '../dto/modify-recipe.dto';
 import { Recipe } from '../entities/recipe.entity';
 import { RecipeRepository } from '../repositories/recipe.repository';
 import { RecipeViewerIdentifier } from '../dto/recipe-viewer-identifier';
-import { MEMORY_CACHE } from '@app/common/cache/cache.constant';
-import { Cache } from 'cache-manager';
 import { Cacheable } from '@app/common/cache/memory-cache.service';
 
 @Injectable()
 export class RecipeService {
-  constructor(
-    private readonly recipeRepository: RecipeRepository,
-    @Inject(MEMORY_CACHE) private readonly cacheManager: Cache,
-  ) {}
+  constructor(private readonly recipeRepository: RecipeRepository) {}
 
   async create(createRecipeDto: CreateRecipeDto): Promise<Recipe> {
     return await this.recipeRepository.create(createRecipeDto);
@@ -60,6 +56,10 @@ export class RecipeService {
     const ret = await this.recipeRepository.findOne(id);
     if (!ret) throw new NotFoundException('Recipe not found');
     return ret;
+  }
+
+  async findTopViewed(): Promise<RecipeListViewResponseDto[]> {
+    return await this.recipeRepository.findTopViewed();
   }
 
   @Cacheable({

--- a/api/libs/recipe/src/services/recipe.service.ts
+++ b/api/libs/recipe/src/services/recipe.service.ts
@@ -26,15 +26,10 @@ export class RecipeService {
 
   async findAll(filterRecipeDto: FilterRecipeDto): Promise<RecipesResponseDto> {
     const results = await this.recipeRepository.findAll(filterRecipeDto);
-    return {
-      results: results.recipes,
-      page: filterRecipeDto.page,
-      count: results.recipes.length,
-      has_next:
-        results.count >
-        (filterRecipeDto.page - 1) * filterRecipeDto.limit +
-          results.recipes.length,
-    };
+    return results.toRecipesResponseDto(
+      filterRecipeDto.page,
+      filterRecipeDto.limit,
+    );
   }
 
   async findAllByFullTextSearch(
@@ -55,15 +50,10 @@ export class RecipeService {
           textSearchRecipeDto.limit,
         ),
       );
-    return {
-      results: results.recipes,
-      page: textSearchRecipeDto.page,
-      count: results.recipes.length,
-      has_next:
-        results.count >
-        (textSearchRecipeDto.page - 1) * textSearchRecipeDto.limit +
-          results.recipes.length,
-    };
+    return results.toRecipesResponseDto(
+      textSearchRecipeDto.page,
+      textSearchRecipeDto.limit,
+    );
   }
 
   async findOne(id: string): Promise<Recipe> {
@@ -94,13 +84,9 @@ export class RecipeService {
     return ret;
   }
 
-  async delete(id: string): Promise<Recipe> {
+  async deleteOne(id: string): Promise<Recipe> {
     const ret = await this.recipeRepository.deleteOne(id);
     if (!ret) throw new NotFoundException('Recipe not found');
     return ret;
-  }
-
-  async deleteAll(filterRecipeDto: FilterRecipeDto): Promise<any> {
-    return await this.recipeRepository.deleteAll(filterRecipeDto);
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
     "start:prod": "node dist/apps/app/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watch --verbose",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./apps/app/test/jest-e2e.json"


### PR DESCRIPTION
## Done

- close #66 
- Use in-memory caching for check recipe-view abusing
- During ttl(60 minutes), recipe view from same user/ip would be not counted
- Add top viewed api => `GET /recipe/top-viewed`

## TODO
 - Getting top viewd recipes is just full-scanning: add index to view_count and need to load test
 - Maybe using redis for sorted cache of indivisual recipe can be a solution: need more research
---

## Notice
