### PR TITLE
[Feat]: add support for mongodb multi-document transaction

### DIFF
--- a/api/libs/auth/src/guards/session-auth.guard.ts
+++ b/api/libs/auth/src/guards/session-auth.guard.ts
@@ -5,14 +5,14 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { Request } from 'express';
-import { AuthRepository } from '../repositories/auth.repository';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY } from '@app/common/decorators/public.decorator';
+import { AuthService } from '../services/auth.service';
 
 @Injectable()
 export class SessionAuthGuard implements CanActivate {
   constructor(
-    private readonly authRepository: AuthRepository,
+    private readonly authService: AuthService,
     private readonly reflector: Reflector,
   ) {}
 
@@ -30,9 +30,7 @@ export class SessionAuthGuard implements CanActivate {
       return true;
     }
     try {
-      const session = await this.authRepository.findBySessionToken(
-        sessionToken,
-      );
+      const session = await this.authService.findBySessionToken(sessionToken);
       request['user'] = session.user;
       request['sessionToken'] = session.session_token;
     } catch {

--- a/api/libs/auth/src/repositories/auth.repository.ts
+++ b/api/libs/auth/src/repositories/auth.repository.ts
@@ -31,15 +31,17 @@ export class AuthRepository {
     keyGenerator: (session: string) => `session:${session}`,
   })
   async findBySessionToken(session: string): Promise<Session> {
-    return await this.sessionModel
-      .findOne({ session_token: session })
-      .populate({
-        path: 'user',
-        populate: {
-          path: 'device_tokens',
-        },
-      })
-      .exec();
+    return (
+      await this.sessionModel
+        .findOne({ session_token: session })
+        .populate({
+          path: 'user',
+          populate: {
+            path: 'device_tokens',
+          },
+        })
+        .exec()
+    )?.toObject();
   }
 
   async deleteOne(id: string): Promise<Session> {

--- a/api/libs/common/src/cache/memory-cache.service.ts
+++ b/api/libs/common/src/cache/memory-cache.service.ts
@@ -25,8 +25,10 @@ export class MemoryCacheService implements LazyDecorator<any, CacheOption> {
         await this.cacheManager.del(key);
       }
       const ret = await method(...args);
-      if (metadata.action === 'get')
-        await this.cacheManager.set(key, ret, metadata.ttl);
+      if (metadata.action === 'get') {
+        if (!ret) return ret;
+        else await this.cacheManager.set(key, ret, metadata.ttl);
+      }
       return ret;
     };
   }

--- a/api/libs/common/src/cache/redis-cache.service.ts
+++ b/api/libs/common/src/cache/redis-cache.service.ts
@@ -25,8 +25,10 @@ export class RedisCacheService implements LazyDecorator<any, CacheOption> {
         await this.cacheManager.del(key);
       }
       const ret = await method(...args);
-      if (metadata.action === 'get')
-        await this.cacheManager.set(key, ret, metadata.ttl);
+      if (metadata.action === 'get') {
+        if (!ret) return ret;
+        else await this.cacheManager.set(key, ret, metadata.ttl);
+      }
       return ret;
     };
   }

--- a/api/libs/common/src/crud-mongo.repository.ts
+++ b/api/libs/common/src/crud-mongo.repository.ts
@@ -11,7 +11,7 @@ export class CrudMongoRepository<Entity, CreateDto, UpdateDto, FilterDto>
 
   async create(createDto: CreateDto): Promise<Entity> {
     const createdEntity = new this.model(createDto);
-    return (await createdEntity.save()).toObject();
+    return (await createdEntity.save())?.toObject();
   }
 
   async findAll(filterDto: FilterDto): Promise<Entity[]> {
@@ -19,7 +19,7 @@ export class CrudMongoRepository<Entity, CreateDto, UpdateDto, FilterDto>
   }
 
   async findOne(id: string): Promise<Entity> {
-    return (await this.model.findOne({ id }).exec()).toObject();
+    return (await this.model.findOne({ id }).exec())?.toObject();
   }
 
   async update(id: string, updateDto: UpdateDto) {
@@ -27,10 +27,10 @@ export class CrudMongoRepository<Entity, CreateDto, UpdateDto, FilterDto>
       await this.model.findOneAndUpdate({ id }, updateDto, {
         new: true,
       })
-    ).toObject();
+    )?.toObject();
   }
 
   async deleteOne(id: string): Promise<Entity> {
-    return (await this.model.findOneAndDelete({ id }).exec()).toObject();
+    return (await this.model.findOneAndDelete({ id }).exec())?.toObject();
   }
 }

--- a/api/libs/common/src/crud-mongo.repository.ts
+++ b/api/libs/common/src/crud-mongo.repository.ts
@@ -11,24 +11,26 @@ export class CrudMongoRepository<Entity, CreateDto, UpdateDto, FilterDto>
 
   async create(createDto: CreateDto): Promise<Entity> {
     const createdEntity = new this.model(createDto);
-    return await createdEntity.save();
+    return (await createdEntity.save()).toObject();
   }
 
   async findAll(filterDto: FilterDto): Promise<Entity[]> {
-    return await this.model.find(filterDto).exec();
+    return (await this.model.find(filterDto).exec()).map((e) => e.toObject());
   }
 
   async findOne(id: string): Promise<Entity> {
-    return await this.model.findOne({ id }).exec();
+    return (await this.model.findOne({ id }).exec()).toObject();
   }
 
   async update(id: string, updateDto: UpdateDto) {
-    return await this.model.findOneAndUpdate({ id }, updateDto, {
-      new: true,
-    });
+    return (
+      await this.model.findOneAndUpdate({ id }, updateDto, {
+        new: true,
+      })
+    ).toObject();
   }
 
   async deleteOne(id: string): Promise<Entity> {
-    return await this.model.findOneAndDelete({ id }).exec();
+    return (await this.model.findOneAndDelete({ id }).exec()).toObject();
   }
 }

--- a/api/libs/common/src/crud.service.ts
+++ b/api/libs/common/src/crud.service.ts
@@ -1,5 +1,6 @@
 import { NotFoundException } from '@nestjs/common';
 import { ICrudRepository } from './crud.repository';
+import { MongoTransactional } from './transaction/mongo-transaction.service';
 
 export class CrudService<Entity, CreateDto, UpdateDto, FilterDto> {
   private repository: ICrudRepository<Entity, CreateDto, UpdateDto, FilterDto>;
@@ -9,14 +10,17 @@ export class CrudService<Entity, CreateDto, UpdateDto, FilterDto> {
     this.repository = repository;
   }
 
+  @MongoTransactional()
   async create(createDto: CreateDto): Promise<Entity> {
     return await this.repository.create(createDto);
   }
 
+  @MongoTransactional({ readOnly: true })
   async findAll(filterDto: FilterDto): Promise<Entity[]> {
     return await this.repository.findAll(filterDto);
   }
 
+  @MongoTransactional({ readOnly: true })
   async findOne(id: string): Promise<Entity> {
     const ret = await this.repository.findOne(id);
     if (!ret) {
@@ -25,6 +29,7 @@ export class CrudService<Entity, CreateDto, UpdateDto, FilterDto> {
     return ret;
   }
 
+  @MongoTransactional()
   async update(id: string, updateDto: UpdateDto): Promise<Entity> {
     const ret = await this.repository.update(id, updateDto);
     if (!ret) {
@@ -33,6 +38,7 @@ export class CrudService<Entity, CreateDto, UpdateDto, FilterDto> {
     return ret;
   }
 
+  @MongoTransactional()
   async deleteOne(id: string): Promise<void> {
     const ret = await this.repository.deleteOne(id);
     if (!ret) {

--- a/api/libs/common/src/log/log.module.ts
+++ b/api/libs/common/src/log/log.module.ts
@@ -13,6 +13,7 @@ import { v4 as uuid } from 'uuid';
           return (req.headers['x-request-id'] as string) ?? uuid().slice(0, 8);
         },
       },
+      global: true,
     }),
   ],
   providers: [LogDecorator],

--- a/api/libs/common/src/mongo.module.ts
+++ b/api/libs/common/src/mongo.module.ts
@@ -2,17 +2,28 @@ import { Global, Module, OnApplicationShutdown } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectConnection, MongooseModule } from '@nestjs/mongoose';
 import { Connection } from 'mongoose';
+import { MongoService } from './mongo.service';
+import { MongoTransactionService } from './transaction/mongo-transaction.service';
 
 @Global()
 @Module({
   imports: [
     MongooseModule.forRootAsync({
-      useFactory: (configService: ConfigService) => ({
+      useFactory: (
+        configService: ConfigService,
+        mongoService: MongoService,
+      ) => ({
         uri: configService.get<string>('DATABASE_URI'),
+        connectionFactory: (conn: Connection) => {
+          conn.plugin(mongoService.addSessionPlugin.bind(mongoService));
+          return conn;
+        },
       }),
-      inject: [ConfigService],
+      inject: [ConfigService, MongoService],
     }),
   ],
+  providers: [MongoService, MongoTransactionService],
+  exports: [MongoService, MongoTransactionService],
 })
 export class MongoModule implements OnApplicationShutdown {
   constructor(@InjectConnection() private readonly connection: Connection) {}

--- a/api/libs/common/src/mongo.service.ts
+++ b/api/libs/common/src/mongo.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { Schema } from 'mongoose';
+import { ClsService } from 'nestjs-cls';
+
+@Injectable()
+export class MongoService {
+  constructor(private readonly clsService: ClsService) {}
+
+  addSessionPlugin(schema: Schema, options: any) {
+    const clsService = this.clsService;
+    schema.pre(
+      [
+        'count',
+        'estimatedDocumentCount',
+        'countDocuments',
+        'deleteMany',
+        'distinct',
+        'find',
+        'findOne',
+        'findOneAndDelete',
+        'findOneAndRemove',
+        'findOneAndReplace',
+        'findOneAndUpdate',
+        'replaceOne',
+        'updateMany',
+      ],
+      async function () {
+        this.session(clsService.get('transaction_session'));
+      },
+    );
+    schema.pre(['updateOne', 'deleteOne'], async function () {
+      this.session(clsService.get('transaction_session'));
+    });
+    schema.pre(['save', 'init', 'validate'], async function () {
+      this.$session(clsService.get('transaction_session'));
+    });
+    schema.pre('aggregate', async function () {
+      this.session(clsService.get('transaction_session'));
+    });
+  }
+}

--- a/api/libs/common/src/mongo.service.ts
+++ b/api/libs/common/src/mongo.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { Schema } from 'mongoose';
 import { ClsService } from 'nestjs-cls';
 
+export const TRANSACTION_SESSION = Symbol('TRANSACTION_SESSION');
+
 @Injectable()
 export class MongoService {
   constructor(private readonly clsService: ClsService) {}
@@ -25,17 +27,17 @@ export class MongoService {
         'updateMany',
       ],
       async function () {
-        this.session(clsService.get('transaction_session'));
+        this.session(clsService.get(TRANSACTION_SESSION));
       },
     );
     schema.pre(['updateOne', 'deleteOne'], async function () {
-      this.session(clsService.get('transaction_session'));
+      this.session(clsService.get(TRANSACTION_SESSION));
     });
     schema.pre(['save', 'init', 'validate'], async function () {
-      this.$session(clsService.get('transaction_session'));
+      this.$session(clsService.get(TRANSACTION_SESSION));
     });
     schema.pre('aggregate', async function () {
-      this.session(clsService.get('transaction_session'));
+      this.session(clsService.get(TRANSACTION_SESSION));
     });
   }
 }

--- a/api/libs/common/src/transaction/mongo-transaction.service.ts
+++ b/api/libs/common/src/transaction/mongo-transaction.service.ts
@@ -1,0 +1,52 @@
+import { InjectConnection } from '@nestjs/mongoose';
+import {
+  Aspect,
+  LazyDecorator,
+  WrapParams,
+  createDecorator,
+} from '@toss/nestjs-aop';
+import { Connection } from 'mongoose';
+import { ClsService } from 'nestjs-cls';
+
+export const MONGO_TRANSACTIONAL = Symbol('MONGO_TRANSACTIONAL');
+
+export type TransactionOption = {
+  readOnly: boolean;
+};
+
+export const MongoTransactional = (option?: TransactionOption) =>
+  createDecorator(MONGO_TRANSACTIONAL, { readOnly: false, ...option });
+
+@Aspect(MONGO_TRANSACTIONAL)
+export class MongoTransactionService
+  implements LazyDecorator<any, TransactionOption>
+{
+  constructor(
+    private readonly clsService: ClsService,
+    @InjectConnection() private readonly conn: Connection,
+  ) {}
+
+  wrap({ method, metadata }: WrapParams<any, TransactionOption>) {
+    return async (...args: any[]) => {
+      if (this.clsService.get('transaction_session')) {
+        return await method(...args);
+      }
+      const session = await this.conn.startSession();
+      session.startTransaction({
+        readPreference: metadata.readOnly ? 'secondaryPreferred' : 'primary',
+      });
+      this.clsService.set('transaction_session', session);
+      try {
+        const ret = await method(...args);
+        await session.commitTransaction();
+        return ret;
+      } catch (e) {
+        console.log('error catched, aborting transaction');
+        await session.abortTransaction();
+        throw e;
+      } finally {
+        session.endSession();
+      }
+    };
+  }
+}

--- a/api/libs/ingredient/src/services/user-ingredient.service.ts
+++ b/api/libs/ingredient/src/services/user-ingredient.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../dto/modify-ingredient.dto';
 import { UserIngredient } from '../entities/user-ingredient.entity';
 import { UserIngredientRepository } from '../repositories/user-ingredient.repository';
+import { MongoTransactional } from '@app/common/transaction/mongo-transaction.service';
 
 interface ImageProcessService {
   getBarcodeInfoFromUrl(
@@ -56,24 +57,28 @@ export class UserIngredientService implements OnModuleInit {
     return ret;
   }
 
+  @MongoTransactional()
   async create(
     createUserIngredientDto: CreateUserIngredientDto,
   ): Promise<UserIngredient> {
     return await this.userIngredientRepository.create(createUserIngredientDto);
   }
 
+  @MongoTransactional({ readOnly: true })
   async findAll(
     filterUserIngredientDto: FilterUserIngredientDto,
   ): Promise<UserIngredient[]> {
     return await this.userIngredientRepository.findAll(filterUserIngredientDto);
   }
 
+  @MongoTransactional({ readOnly: true })
   async findOne(id: string): Promise<UserIngredient> {
     const ret = await this.userIngredientRepository.findOne(id);
     if (!ret) throw new NotFoundException('UserIngredient not found');
     return ret;
   }
 
+  @MongoTransactional()
   async update(
     id: string,
     updateUserIngredientDto: UpdateUserIngredientDto,
@@ -86,12 +91,14 @@ export class UserIngredientService implements OnModuleInit {
     return ret;
   }
 
+  @MongoTransactional()
   async deleteOne(id: string): Promise<UserIngredient> {
     const ret = await this.userIngredientRepository.deleteOne(id);
     if (!ret) throw new NotFoundException('UserIngredient not found');
     return ret;
   }
 
+  @MongoTransactional()
   async deleteAll(
     filterUserIngredientDto: FilterUserIngredientDto,
   ): Promise<any> {

--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -120,11 +120,10 @@ export class RecipeController {
     @Ip() ip: string,
     @ReqUser() user: User,
   ) {
-    await this.recipeService.viewRecipe(
+    return await this.recipeService.findOne(
       id,
       new RecipeViewerIdentifier(user, ip),
     );
-    return await this.recipeService.findOne(id);
   }
 
   /**

--- a/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
@@ -11,6 +11,8 @@ import {
 } from 'class-validator';
 import { Recipe } from '../../entities/recipe.entity';
 import { OmitType } from '@nestjs/swagger';
+import { Schema, Types } from 'mongoose';
+import { User } from '@app/user/entities/user.entity';
 
 export class FilterRecipeDto extends PagenationDto {
   constructor(
@@ -74,7 +76,28 @@ export class RecipeListViewResponseDto extends OmitType(Recipe, [
   'origin_url',
   'recipe_steps',
   'ingredient_requirements',
-] as const) {}
+] as const) {
+  constructor(
+    id: Schema.Types.ObjectId,
+    owner: User,
+    name: string,
+    thumbnail: string,
+    description: string,
+    view_count: number,
+    created_at: Date,
+    updated_at: Date,
+  ) {
+    super();
+    this.id = id;
+    this.owner = null;
+    this.name = name;
+    this.thumbnail = thumbnail;
+    this.description = description;
+    this.view_count = view_count;
+    this.created_at = created_at;
+    this.updated_at = updated_at;
+  }
+}
 
 export class RecipesResponseDto extends PagenationResponseDto {
   results: RecipeListViewResponseDto[];

--- a/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
@@ -78,14 +78,14 @@ export class RecipeListViewResponseDto extends OmitType(Recipe, [
   'ingredient_requirements',
 ] as const) {
   constructor(
-    id: Schema.Types.ObjectId,
-    owner: User,
-    name: string,
-    thumbnail: string,
-    description: string,
-    view_count: number,
-    created_at: Date,
-    updated_at: Date,
+    id: Schema.Types.ObjectId = null,
+    owner: User = null,
+    name: string = null,
+    thumbnail: string = null,
+    description: string = null,
+    view_count: number = null,
+    created_at: Date = null,
+    updated_at: Date = null,
   ) {
     super();
     this.id = id;

--- a/api/libs/recipe/src/repositories/recipe-view-log.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe-view-log.repository.ts
@@ -67,18 +67,20 @@ export class RecipeViewLogRepository extends CrudMongoRepository<
   }
 
   async findAllViewedRecipesInPast1Month() {
-    return await this.recipeViewLogModel
-      .aggregate()
-      .match({
-        created_at: {
-          $gte: calcPast1MonthDate(),
-        },
-      })
-      .group({
-        _id: '$recipe_id',
-        count: { $sum: 1 },
-      })
-      .exec();
+    return (
+      await this.recipeViewLogModel
+        .aggregate()
+        .match({
+          created_at: {
+            $gte: calcPast1MonthDate(),
+          },
+        })
+        .group({
+          _id: '$recipe_id',
+          count: { $sum: 1 },
+        })
+        .exec()
+    ).map((recipeWithCount) => recipeWithCount.toObject());
   }
 
   async findAll5MostViewedRecipesInPast1Month(): Promise<
@@ -99,16 +101,16 @@ export class RecipeViewLogRepository extends CrudMongoRepository<
         ),
       );
       return recipes.map((recipe, index) => {
-        return {
-          id: recipe.id,
-          owner: recipe.owner,
-          name: recipe.name,
-          thumbnail: recipe.thumbnail,
-          description: recipe.description,
-          view_count: recipeIdsWithViews[index].score,
-          created_at: recipe.created_at,
-          updated_at: recipe.updated_at,
-        };
+        return new RecipeListViewResponseDto(
+          recipe.id,
+          null,
+          recipe.name,
+          recipe.thumbnail,
+          recipe.description,
+          recipeIdsWithViews[index].score,
+          recipe.created_at,
+          recipe.updated_at,
+        );
       });
     }
     return await this.recipeViewLogModel

--- a/api/libs/recipe/src/repositories/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe.repository.ts
@@ -16,8 +16,8 @@ import {
 import { Recipe, RecipeDocument } from '../entities/recipe.entity';
 import { deleteNull } from '@app/common/utils/delete-null';
 import { deleteProps } from '@app/common/utils/delete-props';
-import { Cacheable } from '@app/common/cache/cache.service';
 import { Logable } from '@app/common/log/log.decorator';
+import { Cacheable } from '@app/common/cache/cache.service';
 
 @Injectable()
 export class RecipeRepository {
@@ -28,7 +28,7 @@ export class RecipeRepository {
 
   async create(createRecipeDto: CreateRecipeDto): Promise<Recipe> {
     const createdEntity = new this.recipeModel(createRecipeDto);
-    return (await createdEntity.save()).toObject();
+    return (await createdEntity.save())?.toObject();
   }
 
   async findAll(filterRecipeDto: FilterRecipeDto): Promise<RecipesAndCountDto> {
@@ -122,7 +122,7 @@ export class RecipeRepository {
           origin_url: 0,
         })
         .exec()
-    ).toObject();
+    )?.toObject();
   }
 
   async findTopViewed(): Promise<RecipeListViewResponseDto[]> {
@@ -164,7 +164,7 @@ export class RecipeRepository {
       await this.recipeModel
         .findOneAndUpdate({ id }, { $inc: { view_count: 1 } }, { new: true })
         .exec()
-    ).toObject();
+    )?.toObject();
   }
 
   async update(id: string, updateRecipeDto: UpdateRecipeDto): Promise<Recipe> {
@@ -172,11 +172,11 @@ export class RecipeRepository {
       await this.recipeModel
         .findOneAndUpdate({ id }, updateRecipeDto, { new: true })
         .exec()
-    ).toObject();
+    )?.toObject();
   }
 
   async deleteOne(id: string): Promise<Recipe> {
-    return (await this.recipeModel.findOneAndDelete({ id }).exec()).toObject();
+    return (await this.recipeModel.findOneAndDelete({ id }).exec())?.toObject();
   }
 
   async deleteAll(filterRecipeDto: FilterRecipeDto): Promise<any> {

--- a/api/libs/recipe/src/repositories/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe.repository.ts
@@ -28,7 +28,7 @@ export class RecipeRepository {
 
   async create(createRecipeDto: CreateRecipeDto): Promise<Recipe> {
     const createdEntity = new this.recipeModel(createRecipeDto);
-    return await createdEntity.save();
+    return (await createdEntity.save()).toObject();
   }
 
   async findAll(filterRecipeDto: FilterRecipeDto): Promise<RecipesAndCountDto> {
@@ -112,61 +112,71 @@ export class RecipeRepository {
     keyGenerator: (id: string) => `recipe:${id}`,
   })
   async findOne(id: string): Promise<RecipeDto> {
-    return await this.recipeModel
-      .findOne({ id })
-      .select({
-        _id: 0,
-        __v: 0,
-        recipe_raw_text: 0,
-        origin_url: 0,
-      })
-      .exec();
+    return (
+      await this.recipeModel
+        .findOne({ id })
+        .select({
+          _id: 0,
+          __v: 0,
+          recipe_raw_text: 0,
+          origin_url: 0,
+        })
+        .exec()
+    ).toObject();
   }
 
   async findTopViewed(): Promise<RecipeListViewResponseDto[]> {
-    return await this.recipeModel
-      .find()
-      .sort({ view_count: -1 })
-      .limit(10)
-      .select({
-        _id: 0,
-        __v: 0,
-        recipe_raw_text: 0,
-        origin_url: 0,
-        recipe_steps: 0,
-        ingredient_requirements: 0,
-      })
-      .exec();
+    return (
+      await this.recipeModel
+        .find()
+        .sort({ view_count: -1 })
+        .limit(10)
+        .select({
+          _id: 0,
+          __v: 0,
+          recipe_raw_text: 0,
+          origin_url: 0,
+          recipe_steps: 0,
+          ingredient_requirements: 0,
+        })
+        .exec()
+    ).map((recipe) => recipe.toObject());
   }
 
   async findAllByIds(ids: string[]): Promise<RecipeListViewResponseDto[]> {
-    return await this.recipeModel
-      .find({ id: { $in: ids } })
-      .select({
-        _id: 0,
-        __v: 0,
-        recipe_raw_text: 0,
-        origin_url: 0,
-        recipe_steps: 0,
-        ingredient_requirements: 0,
-      })
-      .exec();
+    return (
+      await this.recipeModel
+        .find({ id: { $in: ids } })
+        .select({
+          _id: 0,
+          __v: 0,
+          recipe_raw_text: 0,
+          origin_url: 0,
+          recipe_steps: 0,
+          ingredient_requirements: 0,
+        })
+        .exec()
+    ).map((recipe) => recipe.toObject());
   }
 
   async increaseViewCount(id: string): Promise<Recipe> {
-    return await this.recipeModel
-      .findOneAndUpdate({ id }, { $inc: { view_count: 1 } }, { new: true })
-      .exec();
+    return (
+      await this.recipeModel
+        .findOneAndUpdate({ id }, { $inc: { view_count: 1 } }, { new: true })
+        .exec()
+    ).toObject();
   }
 
   async update(id: string, updateRecipeDto: UpdateRecipeDto): Promise<Recipe> {
-    return await this.recipeModel
-      .findOneAndUpdate({ id }, updateRecipeDto, { new: true })
-      .exec();
+    return (
+      await this.recipeModel
+        .findOneAndUpdate({ id }, updateRecipeDto, { new: true })
+        .exec()
+    ).toObject();
   }
 
   async deleteOne(id: string): Promise<Recipe> {
-    return await this.recipeModel.findOneAndDelete({ id }).exec();
+    return (await this.recipeModel.findOneAndDelete({ id }).exec()).toObject();
   }
 
   async deleteAll(filterRecipeDto: FilterRecipeDto): Promise<any> {

--- a/api/libs/recipe/src/services/recipe.service.spec.ts
+++ b/api/libs/recipe/src/services/recipe.service.spec.ts
@@ -180,9 +180,23 @@ describe('RecipeService', () => {
     it('should return a recipe', async () => {
       const recipe = new Recipe();
       recipeRepository.findOne.mockResolvedValue(recipe);
+      recipeRepository.increaseViewCount.mockResolvedValue(new Recipe());
+      recipeViewLogRepository.create.mockResolvedValue(new RecipeViewLog());
 
-      const result = await service.findOne('1');
+      const result = await service.findOne('1', {
+        ip: '::1',
+        user: {
+          ...new User(),
+          id: '1' as any,
+        },
+      });
 
+      expect(recipeRepository.increaseViewCount).toHaveBeenCalledWith('1');
+      expect(recipeViewLogRepository.create).toHaveBeenCalledWith({
+        recipe_id: '1',
+        user_id: '1',
+        user_ip: '::1',
+      });
       expect(recipeRepository.findOne).toHaveBeenCalledWith('1');
       expect(result).toEqual(recipe);
     });

--- a/api/libs/recipe/src/services/recipe.service.ts
+++ b/api/libs/recipe/src/services/recipe.service.ts
@@ -21,6 +21,7 @@ import { RecipeViewerIdentifier } from '../dto/recipe-view-log/recipe-viewer-ide
 import { MemoryCacheable } from '@app/common/cache/memory-cache.service';
 import { Logable } from '@app/common/log/log.decorator';
 import { RecipeViewLogRepository } from '../repositories/recipe-view-log.repository';
+import { MongoTransactional } from '@app/common/transaction/mongo-transaction.service';
 
 @Injectable()
 export class RecipeService implements OnApplicationBootstrap {
@@ -30,11 +31,13 @@ export class RecipeService implements OnApplicationBootstrap {
   ) {}
 
   @Logable()
+  @MongoTransactional()
   async create(createRecipeDto: CreateRecipeDto): Promise<Recipe> {
     return await this.recipeRepository.create(createRecipeDto);
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findAll(filterRecipeDto: FilterRecipeDto): Promise<RecipesResponseDto> {
     const { page, limit } = filterRecipeDto;
     const results = await this.recipeRepository.findAll(filterRecipeDto);
@@ -42,6 +45,7 @@ export class RecipeService implements OnApplicationBootstrap {
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findAllByFullTextSearch(
     textSearchRecipeDto: TextSearchRecipeDto,
   ): Promise<RecipesResponseDto> {
@@ -62,18 +66,29 @@ export class RecipeService implements OnApplicationBootstrap {
   }
 
   @Logable()
-  async findOne(id: string): Promise<RecipeDto> {
-    const ret = await this.recipeRepository.findOne(id);
+  @MongoTransactional()
+  async findOne(
+    id: string,
+    identifier: RecipeViewerIdentifier,
+  ): Promise<RecipeDto> {
+    const ret = (
+      await Promise.all([
+        this.recipeRepository.findOne(id),
+        this.viewRecipe(id, identifier),
+      ])
+    )[0];
     if (!ret) throw new NotFoundException('Recipe not found');
     return ret;
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findTopViewed(): Promise<RecipeListViewResponseDto[]> {
     return await this.recipeViewLogRepository.findAll5MostViewedRecipesInPast1Month();
   }
 
   @Logable()
+  @MongoTransactional()
   @MemoryCacheable({
     ttl: 60 * 60 * 1000,
     keyGenerator: (id: string, identifier: RecipeViewerIdentifier) =>
@@ -96,6 +111,7 @@ export class RecipeService implements OnApplicationBootstrap {
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async setAllViewedRecipesInPast1Month() {
     if (await this.recipeViewLogRepository.checkIfRecipeViewCountKeyExists())
       return;
@@ -103,6 +119,7 @@ export class RecipeService implements OnApplicationBootstrap {
   }
 
   @Logable()
+  @MongoTransactional()
   async update(id: string, updateRecipeDto: UpdateRecipeDto): Promise<Recipe> {
     const ret = await this.recipeRepository.update(id, updateRecipeDto);
     if (!ret) throw new NotFoundException('Recipe not found');

--- a/api/libs/recipe/src/services/recipe.service.ts
+++ b/api/libs/recipe/src/services/recipe.service.ts
@@ -111,7 +111,6 @@ export class RecipeService implements OnApplicationBootstrap {
   }
 
   @Logable()
-  @MongoTransactional({ readOnly: true })
   async setAllViewedRecipesInPast1Month() {
     if (await this.recipeViewLogRepository.checkIfRecipeViewCountKeyExists())
       return;

--- a/api/libs/user/src/controllers/user.controller.spec.ts
+++ b/api/libs/user/src/controllers/user.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from '../services/user.service';
 import { UserController } from './user.controller';
 import { UserRepository } from '../repositories/user.repository';
-import { AuthRepository } from '@app/auth/repositories/auth.repository';
+import { AuthService } from '@app/auth/services/auth.service';
 
 describe('UserController', () => {
   let controller: UserController;
@@ -14,7 +14,7 @@ describe('UserController', () => {
         UserService,
         { provide: UserRepository, useValue: {} },
         { provide: 'UserModel', useValue: {} },
-        { provide: AuthRepository, useValue: {} },
+        { provide: AuthService, useValue: {} },
       ],
     }).compile();
 

--- a/api/libs/user/src/services/user.service.ts
+++ b/api/libs/user/src/services/user.service.ts
@@ -8,12 +8,14 @@ import { FilterUserDto } from '../dto/filter-user.dto';
 import { User } from '../entities/user.entity';
 import { UserRepository } from '../repositories/user.repository';
 import { Logable } from '@app/common/log/log.decorator';
+import { MongoTransactional } from '@app/common/transaction/mongo-transaction.service';
 
 @Injectable()
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   @Logable()
+  @MongoTransactional()
   async create(createUserDto: CreateUserDto): Promise<User> {
     const { email, username } = createUserDto;
     const [dupEmail, dupUsername] = await Promise.all([
@@ -27,11 +29,13 @@ export class UserService {
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findAll(filterDto: any): Promise<User[]> {
     return await this.userRepository.findAll(filterDto);
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findOne(id: string): Promise<User> {
     const ret = await this.userRepository.findOne(id);
     if (!ret) {
@@ -41,11 +45,13 @@ export class UserService {
   }
 
   @Logable()
+  @MongoTransactional({ readOnly: true })
   async findByEmail(email: string): Promise<User> {
     return await this.userRepository.findByEmail(email);
   }
 
   @Logable()
+  @MongoTransactional()
   async update(id: string, updateDto: UpdateUserDto): Promise<User> {
     const { username } = updateDto;
     const dupUsername = await this.userRepository.findByUsername(username);
@@ -60,6 +66,7 @@ export class UserService {
   }
 
   @Logable()
+  @MongoTransactional()
   async deleteOne(id: string): Promise<User> {
     const ret = await this.userRepository.deleteOne(id);
     if (!ret) {


### PR DESCRIPTION
## Done

- close #93 
- Add transactional decorator by using toss/nestjs-aop and nestjs-cls
- Store mongoose session in cls and apply the session using mongoose pre middleware

#### transaction options
- readonly is true, read preference go to secondaryPreferred
- no readonly goes to primary
- propagation just merge to existing

#### fix cache problem
- cache-manager's local memory store use lodash.cloneDeep
- lodash.cloneDeep occurr inf loop in mongoose model
- Finally call stack exceed
- If repository method cacheable, it must be toObject
- Check optional chaining for avoiding null(not found case)
- 
### TODO

- #0
- Add e2e test using transactions..?

---

## Notice
