### PR TITLE
[Fix]: include prisma query engine to docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,11 +3,14 @@ FROM node:20-slim
 WORKDIR /app
 
 RUN npm install pm2@5.3.0 -g
+RUN apt-get update -y && apt-get install -y openssl
 
 COPY ./ecosystem.config.js .
 
 COPY ./dist/apps/api-bundled/image-process.proto .
 COPY ./dist/apps/api-bundled/main.js .
+COPY ./dist/apps/api-bundled/.prisma/client/* ./node_modules/.prisma/client/
+COPY ./prisma/schema.prisma ./prisma/schema.prisma
 
 EXPOSE 8080
 

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource mysql {

--- a/api/webpack.config.js
+++ b/api/webpack.config.js
@@ -1,4 +1,5 @@
 const TerserPlugin = require('terser-webpack-plugin');
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (options, webpack) => {
   const lazyImports = [
@@ -36,6 +37,18 @@ module.exports = (options, webpack) => {
     },
     plugins: [
       ...options.plugins,
+      new CopyWebpackPlugin({
+        patterns: [
+          {
+            from: `./node_modules/.prisma/client/libquery*.node`,
+            to({ context, absoluteFilename }) {
+              return `./apps/api-bundled/.prisma/client/${absoluteFilename
+                .split('/')
+                .pop()}`;
+            },
+          },
+        ],
+      }),
       new webpack.IgnorePlugin({
         checkResource(resource) {
           if (lazyImports.includes(resource)) {


### PR DESCRIPTION
## Done

- close #103 
- Add query engine binary - for debian-linux(node:20-slim), for arm-linux(in my mac docker)
- Include engine binary to docker image
- npx prisma generate before build in CI process done automatically with @prisma/client post-install-hook
    - https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client#generating-prisma-client-in-the-postinstall-hook-of-prismaclient

---
## Notice
