### PR TITLE
[Feat]: open recipe create endpoint

### DIFF
--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -23,7 +23,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import {
-  CreateRecipeDto,
+  CreateMongoRecipeDto,
   UpdateRecipeDto,
 } from '../dto/recipe/modify-recipe.dto';
 import {
@@ -55,11 +55,7 @@ export class RecipeController {
   @Auth()
   @ApiPostCreated(CreateRecipeResponseDto)
   @Post()
-  async create(
-    @Body() createRecipeDto: CreateRecipeDto,
-    @ReqUser() user: User,
-  ) {
-    createRecipeDto.owner_id = user.id;
+  async create(@Body() createRecipeDto: CreateMongoRecipeDto) {
     return this.recipeService.create(createRecipeDto);
   }
 
@@ -74,13 +70,7 @@ export class RecipeController {
   @Auth()
   @ApiGet(FindRecipesResponseDto)
   @Get()
-  async findAll(
-    @ReqUser() user: User,
-    @Query() filterRecipeDto: FilterRecipeDto,
-  ) {
-    // const filterRecipeDto: FilterRecipeDto = queryBuilder({
-    //   user_id: user.id.toString(),
-    // });
+  async findAll(@Query() filterRecipeDto: FilterRecipeDto) {
     return this.recipeService.findAll(filterRecipeDto);
   }
 

--- a/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/filter-recipe.dto.ts
@@ -5,6 +5,7 @@ import {
 import {
   IsDate,
   IsEnum,
+  IsInt,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -45,6 +46,10 @@ export class FilterRecipeDto extends PagenationDto {
   @IsDate()
   @IsOptional()
   updated_at?: Date;
+
+  @IsInt()
+  @IsOptional()
+  mysql_id?: number;
 }
 
 export enum TextSearchSortBy {

--- a/api/libs/recipe/src/dto/recipe/modify-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/modify-recipe.dto.ts
@@ -69,43 +69,14 @@ export class RecipeStepDto {
 }
 
 export class CreateMongoRecipeDto {
-  constructor(
-    name: string,
-    description: string,
-    owner: string,
-    ingredient_requirements: IngredientRequirementDto[],
-    recipe_steps: RecipeStepDto[],
-    thumbnail: string,
-    recipe_raw_text: string,
-    origin_url: string,
-  ) {
-    this.name = name;
-    this.description = description;
-    this.owner = owner;
-    this.ingredient_requirements = ingredient_requirements.map(
-      (item) =>
-        new IngredientRequirementDto(
-          item.ingredient_id,
-          item.name,
-          item.amount,
-        ),
-    );
-    this.recipe_steps = recipe_steps.map(
-      (item) =>
-        new RecipeStepDto(item.description, item.images, item.ingredients),
-    );
-    this.thumbnail = thumbnail;
-    this.recipe_raw_text = recipe_raw_text;
-    this.origin_url = origin_url;
-  }
-
   @IsString()
   @IsNotEmpty()
   name: string;
 
   @IsInt()
   @Min(1)
-  mysql_id: number;
+  @IsOptional()
+  mysql_id?: number;
 
   @IsString()
   @IsNotEmpty()
@@ -144,8 +115,9 @@ export class CreateRecipeDto {
   @IsNotEmpty()
   name: string;
 
+  @IsOptional()
   @IsMongoId()
-  mongo_id: string;
+  mongo_id?: string;
 
   @IsOptional()
   @IsInt()
@@ -174,6 +146,10 @@ export class UpdateRecipeDto extends PartialType(
   @IsOptional()
   @IsInt()
   view_count?: number;
+
+  @IsOptional()
+  @IsMongoId()
+  mongo_id?: string;
 }
 
 export class UpdateMongoRecipeDto extends PartialType(

--- a/api/libs/recipe/src/dto/recipe/recipe-response.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipe-response.dto.ts
@@ -22,7 +22,7 @@ export class FindTopViewdResponseDto extends OkResponse {
 }
 
 export class FindRecentViewedResponseDto extends OkResponse {
-  data: RecipeListViewResponseDto[];
+  data: RecipesResponseDto;
 }
 
 export class FindOneRecipeResponseDto extends OkResponse {

--- a/api/libs/recipe/src/entities/mongo/mongo.recipe.entity.ts
+++ b/api/libs/recipe/src/entities/mongo/mongo.recipe.entity.ts
@@ -30,7 +30,7 @@ export class Recipe {
   })
   id: MongooseSchema.Types.ObjectId;
 
-  @Prop({ required: true, unique: true, index: true })
+  @Prop({ required: false, index: true })
   mysql_id: number;
 
   @Prop({ required: true })
@@ -68,3 +68,5 @@ export class Recipe {
 }
 
 export const RecipeSchema = SchemaFactory.createForClass(Recipe);
+
+RecipeSchema.index({ '$**': 'text' });

--- a/api/libs/recipe/src/entities/mongo/mongo.recipe.entity.ts
+++ b/api/libs/recipe/src/entities/mongo/mongo.recipe.entity.ts
@@ -1,11 +1,11 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 import { schemaOptions } from '@app/common/utils/schema-option';
 
 export type RecipeDocument = HydratedDocument<Recipe>;
 
 export class IngredientRequirement {
-  ingredient_id: MongooseSchema.Types.ObjectId;
+  ingredient_id: Types.ObjectId;
 
   name: string;
 
@@ -26,9 +26,9 @@ export class Recipe {
     required: true,
     unique: true,
     auto: true,
-    type: MongooseSchema.Types.ObjectId,
+    type: Types.ObjectId,
   })
-  id: MongooseSchema.Types.ObjectId;
+  id: Types.ObjectId;
 
   @Prop({ required: false, index: true })
   mysql_id: number;
@@ -39,8 +39,8 @@ export class Recipe {
   @Prop({ required: true })
   description: string;
 
-  @Prop({ required: false, type: MongooseSchema.Types.ObjectId })
-  owner: MongooseSchema.Types.ObjectId;
+  @Prop({ required: false, type: Types.ObjectId })
+  owner: Types.ObjectId;
 
   @Prop({ required: true, type: Array<IngredientRequirement> })
   ingredient_requirements: Array<IngredientRequirement>;

--- a/api/libs/recipe/src/repositories/recipe/recipe.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe/recipe.repository.ts
@@ -60,6 +60,12 @@ export class RecipeRepository
     return new RecipesAndCountDto(recipes, count);
   }
 
+  async findOneByMongoId(mongoId: string): Promise<Recipe> {
+    return this.prisma.recipe.findUnique({
+      where: { mongo_id: mongoId },
+    });
+  }
+
   async findAllByFullTextSearch(
     _textSearchRecipeDto: TextSearchRecipeDto,
   ): Promise<RecipesAndCountDto> {

--- a/api/libs/recipe/src/services/recipe.service.ts
+++ b/api/libs/recipe/src/services/recipe.service.ts
@@ -133,7 +133,7 @@ export class RecipeService implements OnApplicationBootstrap {
       this.recipeRepository.increaseViewCount(id),
       this.mongoRecipeRepository.increaseViewCountByMySqlId(id),
     ]);
-    if (!ret) throw new NotFoundException('Recipe not found');
+    if (!ret[0] || !ret[1]) throw new NotFoundException('Recipe not found');
     const recipeViewLog = await this.recipeViewLogRepository.create({
       recipe_id: id,
       user_id: identifier.user ? identifier.user.id : undefined,

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -62,7 +62,7 @@ model RecipeBookmark {
 
 model Recipe {
   id              Int              @id @default(autoincrement())
-  mongo_id        String           @unique
+  mongo_id        String?          @unique
   name            String
   description     String
   owner_id        Int?


### PR DESCRIPTION
## Done

- Open recipe create endpoint: for recipe scrap service
- Add mongodb full-text search index and add query method
- fix incr recipe view-count logic

## TODO
- add transactional support for prisma, mongodb both
- creating recipe should success both or not
- or using message queue? that's a point to further considering
---

## Notice
