### PR TITLE
[Refactor]: move business logic to domain object

### DIFF
--- a/api/apps/api-bundled/src/app.module.ts
+++ b/api/apps/api-bundled/src/app.module.ts
@@ -1,5 +1,5 @@
 import { ConfigModule } from '@nestjs/config';
-import { Module } from '@nestjs/common';
+import { ClassSerializerInterceptor, Module } from '@nestjs/common';
 import { UserModule } from '@app/user/user.module';
 import { AuthModule } from '@app/auth/auth.module';
 import { ImageModule } from '@app/image/image.module';
@@ -12,6 +12,7 @@ import { NotiModule } from '@app/noti/noti.module';
 import { RedisModule } from '@app/common/redis.module';
 import { MongoModule } from '@app/common/mongo/mongo.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -31,6 +32,12 @@ import { PrismaModule } from '@app/common/prisma/prisma.module';
     IngredientModule,
     RecipeModule,
     NotiModule,
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ClassSerializerInterceptor,
+    },
   ],
 })
 export class AppModule {}

--- a/api/apps/api/src/app.module.ts
+++ b/api/apps/api/src/app.module.ts
@@ -1,5 +1,5 @@
 import { ConfigModule } from '@nestjs/config';
-import { Module } from '@nestjs/common';
+import { ClassSerializerInterceptor, Module } from '@nestjs/common';
 import { UserModule } from '@app/user/user.module';
 import { AuthModule } from '@app/auth/auth.module';
 import { ImageModule } from '@app/image/image.module';
@@ -12,6 +12,7 @@ import { NotiModule } from '@app/noti/noti.module';
 import { RedisModule } from '@app/common/redis.module';
 import { MongoModule } from '@app/common/mongo/mongo.module';
 import { PrismaModule } from '@app/common/prisma/prisma.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -31,6 +32,12 @@ import { PrismaModule } from '@app/common/prisma/prisma.module';
     IngredientModule,
     RecipeModule,
     NotiModule,
+  ],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ClassSerializerInterceptor,
+    },
   ],
 })
 export class AppModule {}

--- a/api/libs/auth/src/auth.controller.ts
+++ b/api/libs/auth/src/auth.controller.ts
@@ -58,7 +58,10 @@ export class AuthController {
   @Post('register')
   async register(@Body() createUserApiDto: CreateUserApiDto, @Req() req) {
     const userInfo: UserInfo = req.user;
-    const createUserDto: CreateUserDto = { ...createUserApiDto, ...userInfo };
+    const createUserDto: CreateUserDto = {
+      ...createUserApiDto,
+      email: userInfo.email,
+    };
     return await this.authService.register(createUserDto);
   }
 

--- a/api/libs/auth/src/auth.service.ts
+++ b/api/libs/auth/src/auth.service.ts
@@ -1,4 +1,3 @@
-import { User } from '@app/user/domain/user.entity';
 import { UserService } from '@app/user/user.service';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -19,6 +18,7 @@ import { LoginSessionDto } from './dto/token.dto';
 import { v4 as uuidv4 } from 'uuid';
 import { Logable } from '@app/common/log/log.decorator';
 import { UserDto } from '@app/user/dto/user.dto';
+import { UserEntity } from '@app/user/domain/user.entity';
 
 @Injectable()
 export class AuthService {
@@ -51,14 +51,14 @@ export class AuthService {
   }
 
   @Logable()
-  async login(user: User): Promise<LoginSessionDto> {
+  async login(user: UserEntity): Promise<LoginSessionDto> {
     const sessionToken = uuidv4();
     await this.authRepository.create({
       userId: user.id,
       sessionToken,
     });
     return {
-      user: UserDto.from(user),
+      user: UserDto.fromEntity(user),
       sessionToken,
     };
   }

--- a/api/libs/auth/src/domain/session.entity.ts
+++ b/api/libs/auth/src/domain/session.entity.ts
@@ -1,4 +1,14 @@
-import { User } from '@app/user/domain/user.entity';
+import { User, UserEntity } from '@app/user/domain/user.entity';
+import { Session as SessionType } from '@prisma/client';
+
+export class SessionEntity implements SessionType {
+  public readonly id: number;
+  public readonly sessionToken: string;
+  public readonly user?: UserEntity;
+  public readonly userId: number;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+}
 
 export class Session {
   constructor(props: {

--- a/api/libs/auth/src/dto/session.dto.ts
+++ b/api/libs/auth/src/dto/session.dto.ts
@@ -1,6 +1,6 @@
 import { Expose } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
-import { Session } from '@app/auth/domain/session.entity';
+import { SessionEntity } from '@app/auth/domain/session.entity';
 
 export class SessionDto {
   @ApiProperty({ name: 'id' })
@@ -33,7 +33,7 @@ export class SessionDto {
     this.updatedAt = updatedAt;
   }
 
-  static from(session: Session): SessionDto {
+  static fromEntity(session: SessionEntity): SessionDto {
     return new SessionDto(
       session.id,
       session.sessionToken,

--- a/api/libs/auth/src/repositories/auth.repository.interface.ts
+++ b/api/libs/auth/src/repositories/auth.repository.interface.ts
@@ -1,4 +1,4 @@
-import { Session as PrismaSession } from '../domain/session.entity';
+import { SessionEntity as PrismaSession } from '../domain/session.entity';
 import { CreateSessionDto } from '../dto/token.dto';
 import { Session as MongoSession } from '../domain/mongo.session.entity';
 import { ICrudRepository } from '@app/common/repository/crud.repository';

--- a/api/libs/auth/src/repositories/auth.repository.ts
+++ b/api/libs/auth/src/repositories/auth.repository.ts
@@ -4,39 +4,24 @@ import { IAuthRepository } from './auth.repository.interface';
 import { Logable } from '@app/common/log/log.decorator';
 import { Cacheable } from '@app/common/cache/cache.service';
 import { CreateSessionDto } from '@app/auth/dto/token.dto';
-import { Session } from '@app/auth/domain/session.entity';
-import { User } from '@app/user/domain/user.entity';
+import { SessionEntity } from '@app/auth/domain/session.entity';
 
 @Injectable()
 export class AuthRepository implements IAuthRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateSessionDto): Promise<Session> {
-    const ret = await this.prisma.session.create({
+  async create(dto: CreateSessionDto): Promise<SessionEntity> {
+    return await this.prisma.session.create({
       data: dto,
-    });
-    return new Session({
-      id: ret.id,
-      sessionToken: ret.sessionToken,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 
-  async findOne(id: number): Promise<Session> {
-    const ret = await this.prisma.session.findUnique({
+  async findOne(id: number): Promise<SessionEntity> {
+    return await this.prisma.session.findUnique({
       where: { id },
       include: {
         user: true,
       },
-    });
-    return new Session({
-      id: ret.id,
-      sessionToken: ret.sessionToken,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 
@@ -45,8 +30,8 @@ export class AuthRepository implements IAuthRepository {
     ttl: 24 * 60 * 60 * 1000,
     keyGenerator: (session: string) => `session:${session}`,
   })
-  async findBySessionToken(session: string) {
-    const ret = await this.prisma.session.findUnique({
+  async findBySessionToken(session: string): Promise<SessionEntity> {
+    return await this.prisma.session.findUnique({
       where: { sessionToken: session },
       include: {
         user: {
@@ -56,44 +41,19 @@ export class AuthRepository implements IAuthRepository {
         },
       },
     });
-    return new Session({
-      id: ret.id,
-      sessionToken: ret.sessionToken,
-      user: new User(ret.user),
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
-    });
   }
 
-  async findAll() {
-    const ret = await this.prisma.session.findMany();
-    return ret.map(
-      (item) =>
-        new Session({
-          id: item.id,
-          sessionToken: item.sessionToken,
-          userId: item.userId,
-          createdAt: item.createdAt,
-          updatedAt: item.updatedAt,
-        }),
-    );
+  async findAll(): Promise<SessionEntity[]> {
+    return await this.prisma.session.findMany();
   }
 
-  async update(id: number, dto: any): Promise<Session> {
+  async update(id: number, dto: any): Promise<SessionEntity> {
     throw new Error('Method not implemented.');
   }
 
-  async deleteOne(id: number): Promise<Session> {
-    const ret = await this.prisma.session.delete({
+  async deleteOne(id: number): Promise<SessionEntity> {
+    return await this.prisma.session.delete({
       where: { id },
-    });
-    return new Session({
-      id: ret.id,
-      sessionToken: ret.sessionToken,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 
@@ -102,16 +62,9 @@ export class AuthRepository implements IAuthRepository {
     keyGenerator: (session: string) => `session:${session}`,
     action: 'del',
   })
-  async deleteBySessionToken(session: string) {
-    const ret = await this.prisma.session.delete({
+  async deleteBySessionToken(session: string): Promise<SessionEntity> {
+    return await this.prisma.session.delete({
       where: { sessionToken: session },
-    });
-    return new Session({
-      id: ret.id,
-      sessionToken: ret.sessionToken,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 }

--- a/api/libs/auth/test/unit/auth.service.spec.ts
+++ b/api/libs/auth/test/unit/auth.service.spec.ts
@@ -3,13 +3,13 @@ import { AuthService } from '@app/auth/auth.service';
 import { AuthRepository } from '@app/auth/repositories/auth.repository';
 import { UserService } from '@app/user/user.service';
 import { JwtService } from '@nestjs/jwt';
-import { User } from '@app/user/domain/user.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
 import { CreateUserDto } from '@app/user/dto/modify-user.dto';
 import { LoginSessionDto } from '@app/auth/dto/token.dto';
-import { Session } from '@app/auth/domain/session.entity';
 import { OAuthLoginSessionDto } from '@app/auth/dto/oauth.dto';
-import { Diet } from '@app/user/domain/diet.enum';
 import { UserDto } from '@app/user/dto/user.dto';
+import { SessionEntity } from '@app/auth/domain/session.entity';
+import { Diet } from '@prisma/client';
 
 jest.mock('uuid', () => ({
   v4: () => 'mock-uuid',
@@ -33,7 +33,7 @@ describe('AuthService', () => {
   describe('register', () => {
     it('should register a new user and return a login response', async () => {
       const createUserDto: CreateUserDto = new CreateUserDto();
-      const user: User = new User({
+      const user: UserEntity = {
         id: 1,
         email: 'test@test.com',
         username: 'test',
@@ -42,7 +42,7 @@ describe('AuthService', () => {
         thumbnail: '',
         createdAt: new Date(),
         updatedAt: new Date(),
-      });
+      };
       const loginSessionDto: LoginSessionDto = new LoginSessionDto();
       userService.create.mockResolvedValue(user);
       service.login = jest.fn().mockResolvedValue(loginSessionDto);
@@ -57,7 +57,7 @@ describe('AuthService', () => {
 
   describe('login', () => {
     it('should create a new session and return a login response', async () => {
-      const user: User = new User({
+      const user: UserEntity = {
         id: 1,
         email: 'test@test.com',
         username: 'test',
@@ -66,21 +66,19 @@ describe('AuthService', () => {
         thumbnail: '',
         createdAt: new Date(),
         updatedAt: new Date(),
-      });
+      };
       const sessToken = 'mock-uuid';
       const loginSessionDto: LoginSessionDto = {
         sessionToken: sessToken,
-        user: UserDto.from(user),
+        user: UserDto.fromEntity(user),
       };
-      authRepository.create.mockResolvedValueOnce(
-        new Session({
-          id: 1,
-          sessionToken: sessToken,
-          userId: user.id,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        }),
-      );
+      authRepository.create.mockResolvedValueOnce({
+        id: 1,
+        sessionToken: sessToken,
+        userId: user.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as SessionEntity);
 
       const result = await service.login(user);
 
@@ -96,7 +94,7 @@ describe('AuthService', () => {
     it('should return whether user exists and login result', async () => {
       const email = 'test@test.com';
       const username = 'test';
-      const user = new User({
+      const user: UserEntity = {
         id: 1,
         email,
         username,
@@ -105,7 +103,7 @@ describe('AuthService', () => {
         thumbnail: '',
         createdAt: new Date(),
         updatedAt: new Date(),
-      });
+      };
 
       const loginSessionDto: LoginSessionDto = {
         sessionToken: 'sessToken',

--- a/api/libs/common/src/dto/error-response.dto.ts
+++ b/api/libs/common/src/dto/error-response.dto.ts
@@ -1,4 +1,10 @@
-import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 class ErrorResponse {
   success = false;
@@ -7,31 +13,36 @@ class ErrorResponse {
 }
 
 export class UnauthorizedResponse extends ErrorResponse {
-  error = 'Unauthorized';
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 401;
+  error = {
+    name: UnauthorizedException.name,
+    message: 'Unauthorized',
+  };
 }
 
 export class BadRequestResponse extends ErrorResponse {
-  error = 'Bad Request';
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 400;
+  error = {
+    name: BadRequestException.name,
+    message: 'Bad Request',
+  };
 }
 
 export class NotFoundResponse extends ErrorResponse {
-  error = 'Not Found';
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 404;
+  error = {
+    name: NotFoundException.name,
+    message: 'Not Found',
+  };
 }
 
 export class ForbiddenResponse extends ErrorResponse {
-  error = 'Forbidden';
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 403;
+  error = {
+    name: ForbiddenException.name,
+    message: 'Forbidden',
+  };
 }
 
 export class ConflictResponse extends ErrorResponse {
-  error = 'Conflict';
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 409;
+  error = {
+    name: ConflictException.name,
+    message: 'Conflict',
+  };
 }

--- a/api/libs/common/src/dto/pagenation.dto.ts
+++ b/api/libs/common/src/dto/pagenation.dto.ts
@@ -7,11 +7,11 @@ export class PagenationDto {
   @Transform(({ value }) => parseInt(value))
   @IsNumber()
   @Min(1)
-  page: number;
+  page: number = 1;
   @Transform(({ value }) => parseInt(value))
   @IsNumber()
   @Min(1)
-  limit: number;
+  limit: number = 1;
 
   constructor(page: number, limit: number) {
     this.page = page;

--- a/api/libs/common/src/dto/success-response.dto.ts
+++ b/api/libs/common/src/dto/success-response.dto.ts
@@ -1,22 +1,9 @@
-import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
-
 export class SuccessResponse {
   success = true;
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 200;
 }
 
-export class CreatedResponse extends SuccessResponse {
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 201;
-}
+export class CreatedResponse extends SuccessResponse {}
 
-export class NoContentResponse extends SuccessResponse {
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 204;
-}
+export class NoContentResponse extends SuccessResponse {}
 
-export class OkResponse extends SuccessResponse {
-  @ApiExpose({ name: 'status_code' })
-  statusCode = 200;
-}
+export class OkResponse extends SuccessResponse {}

--- a/api/libs/common/src/exception-filters/all-exception.filter.ts
+++ b/api/libs/common/src/exception-filters/all-exception.filter.ts
@@ -1,11 +1,12 @@
 import {
-  ExceptionFilter,
-  Catch,
   ArgumentsHost,
+  Catch,
+  ExceptionFilter,
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
+import { DomainException } from '@app/common/exception-filters/exception';
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -16,15 +17,23 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     const ctx = host.switchToHttp();
 
-    const httpStatus =
-      exception instanceof HttpException
-        ? exception.getStatus()
-        : HttpStatus.INTERNAL_SERVER_ERROR;
+    let httpStatus: HttpStatus;
+    if (exception instanceof HttpException) {
+      httpStatus = exception.getStatus();
+    } else if (exception instanceof DomainException) {
+      httpStatus = HttpStatus.BAD_REQUEST;
+    } else {
+      httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+    }
 
-    const error =
-      exception instanceof HttpException
-        ? exception.getResponse()
-        : { message: 'Internal server error' };
+    let error: string | object;
+    if (exception instanceof HttpException) {
+      error = exception.getResponse();
+    } else if (exception instanceof DomainException) {
+      error = exception.getResponse();
+    } else {
+      error = 'Internal server error';
+    }
 
     console.error(exception);
 

--- a/api/libs/common/src/exception-filters/exception.ts
+++ b/api/libs/common/src/exception-filters/exception.ts
@@ -1,0 +1,8 @@
+export class DomainException extends Error {
+  getResponse(): string | object {
+    return {
+      name: this.constructor.name,
+      message: this.message,
+    };
+  }
+}

--- a/api/libs/ingredient/src/domain/ingredient.entity.ts
+++ b/api/libs/ingredient/src/domain/ingredient.entity.ts
@@ -1,3 +1,15 @@
+import { Ingredient as IngredientType } from '@prisma/client';
+
+export class IngredientEntity implements IngredientType {
+  public readonly id: number;
+  public readonly name: string;
+  public readonly description: string;
+  public readonly thumbnail: string;
+  public readonly icon: string;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+}
+
 export class Ingredient {
   constructor(props: {
     id: number;

--- a/api/libs/ingredient/src/domain/user-ingredient.entity.ts
+++ b/api/libs/ingredient/src/domain/user-ingredient.entity.ts
@@ -1,5 +1,20 @@
 import { FoodType } from '@app/ingredient/domain/food-type.enum';
 import { StoreMethod } from '@app/ingredient/domain/store-method.enum';
+import { $Enums, UserIngredient as UserIngredientType } from '@prisma/client';
+
+export class UserIngredientEntity implements UserIngredientType {
+  public readonly id: number;
+  public readonly name: string;
+  public readonly ingredientId: number;
+  public readonly userId: number;
+  public readonly foodType: $Enums.FoodType;
+  public readonly storeMethod: $Enums.StoreMethod;
+  public readonly count: number;
+  public readonly daysBeforeExpiration: number;
+  public readonly icon: string;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+}
 
 export class UserIngredient {
   constructor(props: {

--- a/api/libs/ingredient/src/dto/user-ingredient.dto.ts
+++ b/api/libs/ingredient/src/dto/user-ingredient.dto.ts
@@ -1,6 +1,6 @@
 import { FoodType } from '@app/ingredient/domain/food-type.enum';
 import { StoreMethod } from '@app/ingredient/domain/store-method.enum';
-import { UserIngredient } from '@app/ingredient/domain/user-ingredient.entity';
+import { UserIngredientEntity } from '@app/ingredient/domain/user-ingredient.entity';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 
 export class UserIngredientDto {
@@ -59,7 +59,7 @@ export class UserIngredientDto {
     this.updatedAt = props.updatedAt;
   }
 
-  static from(userIngredient: UserIngredient) {
+  static fromEntity(userIngredient: UserIngredientEntity) {
     return new UserIngredientDto({
       id: userIngredient.id,
       name: userIngredient.name,

--- a/api/libs/ingredient/src/repositories/user-ingredient.repository.interface.ts
+++ b/api/libs/ingredient/src/repositories/user-ingredient.repository.interface.ts
@@ -1,6 +1,6 @@
 import { ICrudRepository } from '@app/common/repository/crud.repository';
 import { UserIngredient as MongoUserIngredient } from '@app/ingredient/domain/mongo/mongo.user-ingredient.entity';
-import { UserIngredient as PrismaUserIngredient } from '../domain/user-ingredient.entity';
+import { UserIngredientEntity as PrismaUserIngredient } from '../domain/user-ingredient.entity';
 import { CreateUserIngredientDto } from '../dto/create-user-ingredient.dto';
 import { UpdateUserIngredientDto } from '@app/ingredient/dto/update-user-ingredient.dto';
 import { FilterUserIngredientDto } from '@app/ingredient/dto/filter-ingredient.dto';

--- a/api/libs/ingredient/src/repositories/user-ingredient.repository.ts
+++ b/api/libs/ingredient/src/repositories/user-ingredient.repository.ts
@@ -4,48 +4,49 @@ import { PrismaService } from '@app/common/prisma/prisma.service';
 import { FilterUserIngredientDto } from '@app/ingredient/dto/filter-ingredient.dto';
 import { FoodType, StoreMethod } from '@prisma/client';
 import { CreateUserIngredientDto } from '@app/ingredient/dto/create-user-ingredient.dto';
-import { UserIngredient } from '@app/ingredient/domain/user-ingredient.entity';
+import { UserIngredientEntity } from '@app/ingredient/domain/user-ingredient.entity';
 
 @Injectable()
 export class UserIngredientRepository implements IUserIngredientRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateUserIngredientDto) {
-    const ret = await this.prisma.userIngredient.create({
+  async create(dto: CreateUserIngredientDto): Promise<UserIngredientEntity> {
+    return await this.prisma.userIngredient.create({
       data: {
         ...dto,
         foodType: FoodType[dto.foodType],
         storeMethod: StoreMethod[dto.storeMethod],
       },
     });
-    return new UserIngredient(ret);
   }
 
-  async findAllByCond(filterUserIngredientDto: FilterUserIngredientDto) {
-    const ret = await this.prisma.userIngredient.findMany({
+  async findAllByCond(
+    filterUserIngredientDto: FilterUserIngredientDto,
+  ): Promise<UserIngredientEntity[]> {
+    return await this.prisma.userIngredient.findMany({
       where: {
         ...filterUserIngredientDto,
         foodType: FoodType[filterUserIngredientDto.foodType],
         storeMethod: StoreMethod[filterUserIngredientDto.storeMethod],
       },
     });
-    return ret.map((userIngredient) => new UserIngredient(userIngredient));
   }
 
-  async findAll() {
-    const ret = await this.prisma.userIngredient.findMany();
-    return ret.map((userIngredient) => new UserIngredient(userIngredient));
+  async findAll(): Promise<UserIngredientEntity[]> {
+    return await this.prisma.userIngredient.findMany();
   }
 
-  async findOne(id: number) {
-    const ret = await this.prisma.userIngredient.findUnique({
+  async findOne(id: number): Promise<UserIngredientEntity> {
+    return await this.prisma.userIngredient.findUnique({
       where: { id },
     });
-    return new UserIngredient(ret);
   }
 
-  async update(id: number, dto: CreateUserIngredientDto) {
-    const ret = await this.prisma.userIngredient.update({
+  async update(
+    id: number,
+    dto: CreateUserIngredientDto,
+  ): Promise<UserIngredientEntity> {
+    return await this.prisma.userIngredient.update({
       where: { id },
       data: {
         ...dto,
@@ -53,13 +54,11 @@ export class UserIngredientRepository implements IUserIngredientRepository {
         storeMethod: StoreMethod[dto.storeMethod],
       },
     });
-    return new UserIngredient(ret);
   }
 
-  async deleteOne(id: number) {
-    const ret = await this.prisma.userIngredient.delete({
+  async deleteOne(id: number): Promise<UserIngredientEntity> {
+    return await this.prisma.userIngredient.delete({
       where: { id },
     });
-    return new UserIngredient(ret);
   }
 }

--- a/api/libs/ingredient/src/user-ingredient.service.ts
+++ b/api/libs/ingredient/src/user-ingredient.service.ts
@@ -5,7 +5,7 @@ import { ClientGrpc } from '@nestjs/microservices';
 import { BarcodeInfos } from '../../../proto/image_process/BarcodeInfos';
 import { lastValueFrom, Observable } from 'rxjs';
 import { CreateUserIngredientDto } from './dto/create-user-ingredient.dto';
-import { UserIngredient } from './domain/user-ingredient.entity';
+import { UserIngredientEntity } from './domain/user-ingredient.entity';
 import { UserIngredientRepository } from './repositories/user-ingredient.repository';
 import { CrudService } from '@app/common/crud.service';
 import { UpdateUserIngredientDto } from '@app/ingredient/dto/update-user-ingredient.dto';
@@ -21,7 +21,7 @@ interface ImageProcessService {
 @Injectable()
 export class UserIngredientService
   extends CrudService<
-    UserIngredient,
+    UserIngredientEntity,
     CreateUserIngredientDto,
     UpdateUserIngredientDto
   >

--- a/api/libs/noti/src/domain/device-token.entity.ts
+++ b/api/libs/noti/src/domain/device-token.entity.ts
@@ -1,3 +1,13 @@
+import { DeviceToken as DeviceTokenType } from '@prisma/client';
+
+export class DeviceTokenEntity implements DeviceTokenType {
+  public readonly id: number;
+  public readonly userId: number;
+  public readonly fcmDeviceToken: string;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+}
+
 export class DeviceToken {
   constructor(props: {
     id: number;

--- a/api/libs/noti/src/domain/noti.entity.ts
+++ b/api/libs/noti/src/domain/noti.entity.ts
@@ -1,3 +1,13 @@
+import { Noti as NotiType } from '@prisma/client';
+
+export class NotiEntity implements NotiType {
+  public readonly id: number;
+  public readonly userId: number;
+  public readonly content: string;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+}
+
 export class Noti {
   constructor(props: {
     id: number;

--- a/api/libs/noti/src/dto/device-token.dto.ts
+++ b/api/libs/noti/src/dto/device-token.dto.ts
@@ -1,4 +1,4 @@
-import { DeviceToken } from '@app/noti/domain/device-token.entity';
+import { DeviceTokenEntity } from '@app/noti/domain/device-token.entity';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 
 export class DeviceTokenDto {
@@ -30,7 +30,7 @@ export class DeviceTokenDto {
     this.updatedAt = props.updatedAt;
   }
 
-  static from(deviceToken: DeviceToken) {
+  static fromEntity(deviceToken: DeviceTokenEntity) {
     return new DeviceTokenDto({
       id: deviceToken.id,
       userId: deviceToken.userId,

--- a/api/libs/noti/src/dto/noti.dto.ts
+++ b/api/libs/noti/src/dto/noti.dto.ts
@@ -1,4 +1,4 @@
-import { Noti } from '@app/noti/domain/noti.entity';
+import { NotiEntity } from '@app/noti/domain/noti.entity';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 
 export class NotiDto {
@@ -17,7 +17,6 @@ export class NotiDto {
 
   constructor(props: {
     id: number;
-
     userId: number;
     content: string;
     createdAt: Date;
@@ -30,7 +29,7 @@ export class NotiDto {
     this.updatedAt = props.updatedAt;
   }
 
-  static from(noti: Noti) {
+  static fromEntity(noti: NotiEntity) {
     return new NotiDto({
       id: noti.id,
       userId: noti.userId,

--- a/api/libs/noti/src/noti.controller.ts
+++ b/api/libs/noti/src/noti.controller.ts
@@ -51,7 +51,7 @@ export class NotiController {
     const deviceToken = await this.deviceTokenService.create(
       createDeviceTokenDto,
     );
-    return DeviceTokenDto.from(deviceToken);
+    return DeviceTokenDto.fromEntity(deviceToken);
   }
 
   /**
@@ -62,7 +62,7 @@ export class NotiController {
   @Post()
   async createNoti(@Body() createNotiDto: CreateNotiDto) {
     const noti = await this.notiService.create(createNotiDto);
-    return NotiDto.from(noti);
+    return NotiDto.fromEntity(noti);
   }
 
   @Auth()
@@ -70,7 +70,7 @@ export class NotiController {
   @Get()
   async findAllNotis(@ReqUser() user: User) {
     const notis = await this.notiService.findAll();
-    return notis.map((noti) => NotiDto.from(noti));
+    return notis.map((noti) => NotiDto.fromEntity(noti));
   }
 
   @Auth()
@@ -78,7 +78,7 @@ export class NotiController {
   @Get(':id')
   async findOneNoti(@Param('id', ParseIntPipe) id: number) {
     const noti = await this.notiService.findOne(id);
-    return NotiDto.from(noti);
+    return NotiDto.fromEntity(noti);
   }
 
   @Auth()
@@ -89,7 +89,7 @@ export class NotiController {
     @Body() updateNotiDto: UpdateNotiDto,
   ) {
     const noti = await this.notiService.update(id, updateNotiDto);
-    return NotiDto.from(noti);
+    return NotiDto.fromEntity(noti);
   }
 
   @Auth()

--- a/api/libs/noti/src/repository/device-token.repository.interface.ts
+++ b/api/libs/noti/src/repository/device-token.repository.interface.ts
@@ -1,5 +1,5 @@
 import { DeviceToken as MongoDeviceToken } from '@app/noti/domain/mongo/mongo.device-token.entity';
-import { DeviceToken as PrismaDeviceToken } from '@app/noti/domain/device-token.entity';
+import { DeviceTokenEntity as PrismaDeviceToken } from '@app/noti/domain/device-token.entity';
 import { CreateDeviceTokenDto } from '../dto/create-device-token.dto';
 import { ICrudRepository } from '@app/common/repository/crud.repository';
 

--- a/api/libs/noti/src/repository/device-token.repository.ts
+++ b/api/libs/noti/src/repository/device-token.repository.ts
@@ -2,39 +2,35 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { IDeviceTokenRepository } from './device-token.repository.interface';
 import { CreateDeviceTokenDto } from '@app/noti/dto/create-device-token.dto';
-import { DeviceToken } from '@app/noti/domain/device-token.entity';
+import { DeviceTokenEntity } from '@app/noti/domain/device-token.entity';
 
 @Injectable()
 export class DeviceTokenRepository implements IDeviceTokenRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateDeviceTokenDto) {
-    const ret = await this.prisma.deviceToken.create({
+  async create(dto: CreateDeviceTokenDto): Promise<DeviceTokenEntity> {
+    return await this.prisma.deviceToken.create({
       data: dto,
     });
-    return new DeviceToken(ret);
   }
 
-  async findAll() {
-    const ret = await this.prisma.deviceToken.findMany();
-    return ret.map((item) => new DeviceToken(item));
+  async findAll(): Promise<DeviceTokenEntity[]> {
+    return await this.prisma.deviceToken.findMany();
   }
 
-  async findOne(id: number) {
-    const ret = await this.prisma.deviceToken.findUnique({
+  async findOne(id: number): Promise<DeviceTokenEntity> {
+    return await this.prisma.deviceToken.findUnique({
       where: { id },
     });
-    return new DeviceToken(ret);
   }
 
-  async update(id: number, dto: any): Promise<DeviceToken> {
+  async update(id: number, dto: any): Promise<DeviceTokenEntity> {
     throw new Error('Method not implemented.');
   }
 
-  async deleteOne(id: number) {
-    const ret = await this.prisma.deviceToken.delete({
+  async deleteOne(id: number): Promise<DeviceTokenEntity> {
+    return await this.prisma.deviceToken.delete({
       where: { id },
     });
-    return new DeviceToken(ret);
   }
 }

--- a/api/libs/noti/src/repository/noti.repository.interface.ts
+++ b/api/libs/noti/src/repository/noti.repository.interface.ts
@@ -1,7 +1,7 @@
 import { ICrudRepository } from '@app/common/repository/crud.repository';
 import { CreateNotiDto } from '../dto/create-noti.dto';
 import { Noti as MongoNoti } from '@app/noti/domain/mongo/mongo.noti.entity';
-import { Noti as PrismaNoti } from '@app/noti/domain/noti.entity';
+import { NotiEntity as PrismaNoti } from '@app/noti/domain/noti.entity';
 import { UpdateNotiDto } from '@app/noti/dto/update-noti.dto';
 
 type Noti = MongoNoti | PrismaNoti;

--- a/api/libs/noti/src/repository/noti.repository.ts
+++ b/api/libs/noti/src/repository/noti.repository.ts
@@ -2,44 +2,39 @@ import { INotiRepository } from './noti.repository.interface';
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
 import { CreateNotiDto } from '@app/noti/dto/create-noti.dto';
-import { Noti } from '@app/noti/domain/noti.entity';
 import { UpdateNotiDto } from '@app/noti/dto/update-noti.dto';
+import { NotiEntity } from '@app/noti/domain/noti.entity';
 
 @Injectable()
 export class NotiRepository implements INotiRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateNotiDto) {
-    const ret = await this.prisma.noti.create({
+  async create(dto: CreateNotiDto): Promise<NotiEntity> {
+    return await this.prisma.noti.create({
       data: dto,
     });
-    return new Noti(ret);
   }
 
-  async findAll() {
-    const ret = await this.prisma.noti.findMany();
-    return ret.map((item) => new Noti(item));
+  async findAll(): Promise<NotiEntity[]> {
+    return await this.prisma.noti.findMany();
   }
 
-  async findOne(id: number) {
-    const ret = await this.prisma.noti.findUnique({
+  async findOne(id: number): Promise<NotiEntity> {
+    return await this.prisma.noti.findUnique({
       where: { id },
     });
-    return new Noti(ret);
   }
 
-  async update(id: number, dto: UpdateNotiDto) {
-    const ret = await this.prisma.noti.update({
+  async update(id: number, dto: UpdateNotiDto): Promise<NotiEntity> {
+    return await this.prisma.noti.update({
       where: { id },
       data: dto,
     });
-    return new Noti(ret);
   }
 
-  async deleteOne(id: number) {
-    const ret = await this.prisma.noti.delete({
+  async deleteOne(id: number): Promise<NotiEntity> {
+    return await this.prisma.noti.delete({
       where: { id },
     });
-    return new Noti(ret);
   }
 }

--- a/api/libs/noti/src/service/device-token.service.ts
+++ b/api/libs/noti/src/service/device-token.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { DeviceTokenRepository } from '../repository/device-token.repository';
 import { CreateDeviceTokenDto } from '../dto/create-device-token.dto';
-import { DeviceToken } from '@app/noti/domain/device-token.entity';
+import { DeviceTokenEntity } from '@app/noti/domain/device-token.entity';
 import { CrudService } from '@app/common/crud.service';
 
 @Injectable()
 export class DeviceTokenService extends CrudService<
-  DeviceToken,
+  DeviceTokenEntity,
   CreateDeviceTokenDto,
   any
 > {

--- a/api/libs/noti/src/service/noti.service.ts
+++ b/api/libs/noti/src/service/noti.service.ts
@@ -1,14 +1,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Messaging } from 'firebase-admin/messaging';
 import { CrudService } from '@app/common/crud.service';
-import { Noti } from '@app/noti/domain/noti.entity';
+import { NotiEntity } from '@app/noti/domain/noti.entity';
 import { CreateNotiDto } from '../dto/create-noti.dto';
 import { NotiRepository } from '../repository/noti.repository';
 import { UpdateNotiDto } from '@app/noti/dto/update-noti.dto';
 
 @Injectable()
 export class NotiService extends CrudService<
-  Noti,
+  NotiEntity,
   CreateNotiDto,
   UpdateNotiDto
 > {

--- a/api/libs/recipe/src/controllers/recipe-bookmark.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe-bookmark.controller.ts
@@ -24,6 +24,7 @@ import { CreateRecipeBookmarkDto } from '../dto/recipe-bookmark/create-recipe-bo
 import { ReqUser } from '@app/common/decorators/req-user.decorator';
 import { User } from '@app/user/domain/user.entity';
 import { FilterRecipeBookmarkDto } from '../dto/recipe-bookmark/filter-recipe-bookmark.dto';
+import { RecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmark.dto';
 
 @ApiTags('RecipeBookmark')
 @Controller('recipe-bookmark')
@@ -38,7 +39,10 @@ export class RecipeBookmarkController {
     @ReqUser() user: User,
   ) {
     createRecipeBookmarkDto.userId = user.id;
-    return await this.recipeBookmarkService.create(createRecipeBookmarkDto);
+    const ret = await this.recipeBookmarkService.create(
+      createRecipeBookmarkDto,
+    );
+    return RecipeBookmarkDto.fromEntity(ret);
   }
 
   /**

--- a/api/libs/recipe/src/controllers/recipe.controller.ts
+++ b/api/libs/recipe/src/controllers/recipe.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiPostCreated,
 } from '@app/common/decorators/http-method.decorator';
 import { ReqUser } from '@app/common/decorators/req-user.decorator';
-import { User } from '@app/user/domain/user.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
 import {
   Body,
   Controller,
@@ -99,7 +99,7 @@ export class RecipeController {
   async findAllRecentViewed(
     @Query()
     filterRecipeDto: FilterRecipeDto,
-    @ReqUser() user: User,
+    @ReqUser() user: UserEntity,
   ) {
     return this.recipeService.findAllRecentViewed(
       filterRecipeDto,
@@ -119,7 +119,7 @@ export class RecipeController {
   async findOne(
     @Param('id', ParseIntPipe) id: number,
     @Ip() ip: string,
-    @ReqUser() user: User,
+    @ReqUser() user: UserEntity,
   ) {
     return await this.recipeService.findOne(
       id,

--- a/api/libs/recipe/src/domain/recipe-bookmark.entity.ts
+++ b/api/libs/recipe/src/domain/recipe-bookmark.entity.ts
@@ -1,5 +1,56 @@
-import { Recipe } from './recipe.entity';
-import { User } from '@app/user/domain/user.entity';
+import { Recipe, RecipeEntity } from './recipe.entity';
+import { User, UserEntity } from '@app/user/domain/user.entity';
+import { RecipeBookmark as RecipeBookmarkType } from '@prisma/client';
+import { CreateRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/create-recipe-bookmark.dto';
+import {
+  RecipeNotExistsException,
+  UserNotExistsException,
+} from '@app/recipe/exception/domain.exception';
+import { isNil } from '@nestjs/common/utils/shared.utils';
+
+export class RecipeBookmarkEntity implements RecipeBookmarkType {
+  public readonly id: number;
+  public readonly recipeId: number;
+  public readonly recipe?: RecipeEntity;
+  public readonly userId: number;
+  public readonly user?: UserEntity;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(props: {
+    id: number;
+    recipeId: number;
+    recipe?: RecipeEntity;
+    userId: number;
+    user?: UserEntity;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = props.id;
+    this.recipeId = props.recipeId;
+    this.recipe = props.recipe;
+    this.userId = props.userId;
+    this.user = props.user;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static from(recipeBookmark: RecipeBookmark) {
+    return new RecipeBookmarkEntity({
+      id: recipeBookmark.id,
+      recipeId: recipeBookmark.recipeId,
+      recipe: recipeBookmark.recipe
+        ? RecipeEntity.from(recipeBookmark.recipe)
+        : undefined,
+      userId: recipeBookmark.userId,
+      user: recipeBookmark.user
+        ? UserEntity.from(recipeBookmark.user)
+        : undefined,
+      createdAt: recipeBookmark.createdAt,
+      updatedAt: recipeBookmark.updatedAt,
+    });
+  }
+}
 
 export class RecipeBookmark {
   constructor(props: {
@@ -60,5 +111,26 @@ export class RecipeBookmark {
 
   get updatedAt(): Date {
     return this._updatedAt;
+  }
+
+  static create(
+    dto: CreateRecipeBookmarkDto,
+    recipe: RecipeEntity,
+    user: UserEntity,
+    dateTime: Date,
+  ) {
+    if (isNil(recipe)) {
+      throw new RecipeNotExistsException();
+    }
+    if (isNil(user)) {
+      throw new UserNotExistsException();
+    }
+    return new RecipeBookmark({
+      id: null,
+      recipeId: recipe.id,
+      userId: user.id,
+      createdAt: dateTime,
+      updatedAt: dateTime,
+    });
   }
 }

--- a/api/libs/recipe/src/domain/recipe.entity.ts
+++ b/api/libs/recipe/src/domain/recipe.entity.ts
@@ -1,4 +1,61 @@
-import { User } from '@app/user/domain/user.entity';
+import { User, UserEntity } from '@app/user/domain/user.entity';
+import { Recipe as RecipeType } from '@prisma/client';
+
+export class RecipeEntity implements RecipeType {
+  public readonly id: number;
+  public readonly mongoId: string | null;
+  public readonly name: string;
+  public readonly description: string;
+  public readonly ownerId: number | null;
+  public readonly owner?: UserEntity | null;
+  public readonly thumbnail: string;
+  public readonly originUrl: string;
+  public readonly viewCount: number;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(props: {
+    id: number;
+    mongoId: string | null;
+    name: string;
+    description: string;
+    ownerId: number | null;
+    owner?: UserEntity | null;
+    thumbnail: string;
+    originUrl: string;
+    viewCount: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = props.id;
+    this.mongoId = props.mongoId;
+    this.name = props.name;
+    this.description = props.description;
+    this.ownerId = props.ownerId;
+    this.owner = props.owner;
+    this.thumbnail = props.thumbnail;
+    this.originUrl = props.originUrl;
+    this.viewCount = props.viewCount;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static from(recipe: Recipe) {
+    return new RecipeEntity({
+      id: recipe.id,
+      mongoId: recipe.mongoId,
+      name: recipe.name,
+      description: recipe.description,
+      ownerId: recipe.ownerId,
+      owner: recipe.owner ? UserEntity.from(recipe.owner) : undefined,
+      thumbnail: recipe.thumbnail,
+      originUrl: recipe.originUrl,
+      viewCount: recipe.viewCount,
+      createdAt: recipe.createdAt,
+      updatedAt: recipe.updatedAt,
+    });
+  }
+}
 
 export class Recipe {
   constructor(props: {

--- a/api/libs/recipe/src/dto/recipe-bookmark/filter-recipe-bookmark.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-bookmark/filter-recipe-bookmark.dto.ts
@@ -9,4 +9,10 @@ export class FilterRecipeBookmarkDto extends PagenationDto {
   @IsOptional()
   @IsInt()
   userId?: number;
+
+  @ApiHideProperty()
+  @Expose({ name: 'recipe_id' })
+  @IsOptional()
+  @IsInt()
+  recipeId?: number;
 }

--- a/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmark.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmark.dto.ts
@@ -1,0 +1,58 @@
+import { RecipeDto } from '@app/recipe/dto/recipe/recipe.dto';
+import { UserDto } from '@app/user/dto/user.dto';
+import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import { RecipeBookmarkEntity } from '@app/recipe/domain/recipe-bookmark.entity';
+
+export class RecipeBookmarkDto {
+  id: number;
+
+  @ApiExpose({ name: 'recipe_id' })
+  recipeId: number;
+
+  recipe?: RecipeDto;
+
+  @ApiExpose({ name: 'user_id' })
+  userId: number;
+
+  user?: UserDto;
+
+  @ApiExpose({ name: 'created_at' })
+  createdAt: Date;
+
+  @ApiExpose({ name: 'updated_at' })
+  updatedAt: Date;
+
+  constructor(props: {
+    id: number;
+    recipeId: number;
+    recipe?: RecipeDto;
+    userId: number;
+    user?: UserDto;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = props.id;
+    this.recipeId = props.recipeId;
+    this.recipe = props.recipe;
+    this.userId = props.userId;
+    this.user = props.user;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static fromEntity(recipeBookmark: RecipeBookmarkEntity) {
+    return new RecipeBookmarkDto({
+      id: recipeBookmark.id,
+      recipeId: recipeBookmark.recipeId,
+      recipe: recipeBookmark.recipe
+        ? RecipeDto.fromEntity(recipeBookmark.recipe)
+        : undefined,
+      userId: recipeBookmark.userId,
+      user: recipeBookmark.user
+        ? UserDto.fromEntity(recipeBookmark.user)
+        : undefined,
+      createdAt: recipeBookmark.createdAt,
+      updatedAt: recipeBookmark.updatedAt,
+    });
+  }
+}

--- a/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-count.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-count.dto.ts
@@ -1,8 +1,11 @@
 import { RecipeBookmarksItemDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmarks-item.dto';
 import { RecipeBookmarksResponseDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmarks-response.dto';
+import { Type } from 'class-transformer';
 
 export class RecipeBookmarksAndCountDto {
+  @Type(() => RecipeBookmarksItemDto)
   recipes: RecipeBookmarksItemDto[];
+
   count: number;
 
   constructor(recipes: RecipeBookmarksItemDto[], count: number) {

--- a/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-item.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-item.dto.ts
@@ -1,11 +1,7 @@
-import { OmitType } from '@nestjs/swagger';
-import { RecipeDto } from '@app/recipe/dto/recipe/recipe.dto';
+import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import { RecipesItemDto } from '@app/recipe/dto/recipe/recipes-item.dto';
 
-export class RecipeBookmarksItemDto extends OmitType(RecipeDto, [
-  'mongoId',
-  'ownerId',
-  'owner',
-  'originUrl',
-]) {
+export class RecipeBookmarksItemDto extends RecipesItemDto {
+  @ApiExpose({ name: 'recipe_bookmark_id' })
   recipeBookmarkId: number;
 }

--- a/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-response.dto.ts
+++ b/api/libs/recipe/src/dto/recipe-bookmark/recipe-bookmarks-response.dto.ts
@@ -1,7 +1,9 @@
 import { PagenationResponseDto } from '@app/common/dto/pagenation.dto';
 import { RecipeBookmarksItemDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmarks-item.dto';
+import { Type } from 'class-transformer';
 
 export class RecipeBookmarksResponseDto extends PagenationResponseDto {
+  @Type(() => RecipeBookmarksItemDto)
   results: RecipeBookmarksItemDto[];
 
   constructor(

--- a/api/libs/recipe/src/dto/recipe-view-log/recipe-viewer-identifier.ts
+++ b/api/libs/recipe/src/dto/recipe-view-log/recipe-viewer-identifier.ts
@@ -1,12 +1,12 @@
-import { User } from '@app/user/domain/user.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
 import { IsIP } from 'class-validator';
 
 export class RecipeViewerIdentifier {
-  user: User;
+  user: UserEntity;
   @IsIP()
   ip: string;
 
-  constructor(user: User, ip: string) {
+  constructor(user: UserEntity, ip: string) {
     this.user = user;
     this.ip = ip;
   }

--- a/api/libs/recipe/src/dto/recipe/recipe-detail.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipe-detail.dto.ts
@@ -1,7 +1,37 @@
-import { OmitType } from '@nestjs/swagger';
-import { MongoRecipeDto } from '@app/recipe/dto/recipe/mongo-recipe.dto';
+import { IngredientRequirementDto } from '@app/recipe/dto/recipe/ingredient-requirement.dto';
+import { RecipeStepDto } from '@app/recipe/dto/recipe/recipe-step.dto';
+import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import { Type } from 'class-transformer';
 
-export class RecipeDetailDto extends OmitType(MongoRecipeDto, [
-  'recipeRawText',
-  'originUrl',
-]) {}
+export class RecipeDetailDto {
+  public readonly id: number;
+
+  @ApiExpose({ name: 'mongo_id' })
+  public readonly mongoId: string;
+
+  public readonly name: string;
+
+  public readonly description: string;
+
+  @ApiExpose({ name: 'owner_id' })
+  public readonly ownerId: number;
+
+  @Type(() => IngredientRequirementDto)
+  @ApiExpose({ name: 'ingredient_requirements' })
+  public readonly ingredientRequirements: Array<IngredientRequirementDto>;
+
+  @Type(() => RecipeStepDto)
+  @ApiExpose({ name: 'recipe_steps' })
+  public readonly recipeSteps: Array<RecipeStepDto>;
+
+  public readonly thumbnail: string;
+
+  @ApiExpose({ name: 'view_count' })
+  public readonly viewCount: number;
+
+  @ApiExpose({ name: 'created_at' })
+  public readonly createdAt: Date;
+
+  @ApiExpose({ name: 'updated_at' })
+  public readonly updatedAt: Date;
+}

--- a/api/libs/recipe/src/dto/recipe/recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipe.dto.ts
@@ -1,6 +1,6 @@
-import { User } from '@app/user/domain/user.entity';
-import { Recipe } from '@app/recipe/domain/recipe.entity';
+import { RecipeEntity } from '@app/recipe/domain/recipe.entity';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import { UserDto } from '@app/user/dto/user.dto';
 
 export class RecipeDto {
   id: number;
@@ -15,7 +15,7 @@ export class RecipeDto {
   @ApiExpose({ name: 'owner_id' })
   ownerId: number | null;
 
-  owner?: User | null;
+  owner?: UserDto | null;
 
   thumbnail: string;
 
@@ -37,7 +37,7 @@ export class RecipeDto {
     name: string;
     description: string;
     ownerId: number | null;
-    owner?: User | null;
+    owner?: UserDto | null;
     thumbnail: string;
     originUrl: string;
     viewCount: number;
@@ -57,14 +57,14 @@ export class RecipeDto {
     this.updatedAt = props.updatedAt;
   }
 
-  static from(recipe: Recipe) {
+  static fromEntity(recipe: RecipeEntity) {
     return new RecipeDto({
       id: recipe.id,
       mongoId: recipe.mongoId,
       name: recipe.name,
       description: recipe.description,
       ownerId: recipe.ownerId,
-      owner: recipe.owner,
+      owner: UserDto.fromEntity(recipe.owner),
       thumbnail: recipe.thumbnail,
       originUrl: recipe.originUrl,
       viewCount: recipe.viewCount,

--- a/api/libs/recipe/src/dto/recipe/recipes-count.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipes-count.dto.ts
@@ -1,8 +1,11 @@
 import { RecipesItemDto } from '@app/recipe/dto/recipe/recipes-item.dto';
 import { RecipesResponseDto } from '@app/recipe/dto/recipe/recipes-response.dto';
+import { Type } from 'class-transformer';
 
 export class RecipesAndCountDto {
+  @Type(() => RecipesItemDto)
   recipes: RecipesItemDto[];
+
   count: number;
 
   constructor(recipes: RecipesItemDto[], count: number) {

--- a/api/libs/recipe/src/dto/recipe/recipes-item.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipes-item.dto.ts
@@ -1,22 +1,32 @@
-import { OmitType } from '@nestjs/swagger';
-import { RecipeDto } from '@app/recipe/dto/recipe/recipe.dto';
+import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 
-export class RecipesItemDto extends OmitType(RecipeDto, [
-  'mongoId',
-  'ownerId',
-  'owner',
-  'originUrl',
-]) {
+export class RecipesItemDto {
+  public readonly id: number;
+
+  public readonly name: string;
+
+  public readonly thumbnail: string;
+
+  public readonly description: string;
+
+  @ApiExpose({ name: 'view_count' })
+  public readonly viewCount: number;
+
+  @ApiExpose({ name: 'created_at' })
+  public readonly createdAt: Date;
+
+  @ApiExpose({ name: 'updated_at' })
+  public readonly updatedAt: Date;
+
   constructor(
-    public readonly id: number = null,
-    public readonly name: string = null,
-    public readonly thumbnail: string = null,
-    public readonly description: string = null,
-    public readonly viewCount: number = null,
-    public readonly createdAt: Date = null,
-    public readonly updatedAt: Date = null,
+    id: number = null,
+    name: string = null,
+    thumbnail: string = null,
+    description: string = null,
+    viewCount: number = null,
+    createdAt: Date = null,
+    updatedAt: Date = null,
   ) {
-    super();
     this.id = id;
     this.name = name;
     this.thumbnail = thumbnail;

--- a/api/libs/recipe/src/dto/recipe/recipes-response.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/recipes-response.dto.ts
@@ -1,7 +1,9 @@
 import { PagenationResponseDto } from '@app/common/dto/pagenation.dto';
 import { RecipesItemDto } from '@app/recipe/dto/recipe/recipes-item.dto';
+import { Type } from 'class-transformer';
 
 export class RecipesResponseDto extends PagenationResponseDto {
+  @Type(() => RecipesItemDto)
   results: RecipesItemDto[];
 
   constructor(

--- a/api/libs/recipe/src/dto/recipe/update-mongo-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/update-mongo-recipe.dto.ts
@@ -1,18 +1,74 @@
-import { OmitType, PartialType } from '@nestjs/swagger';
-import { IsInt, IsOptional } from 'class-validator';
-import { CreateMongoRecipeDto } from './create-mongo-recipe.dto';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Min,
+  ValidateNested,
+} from 'class-validator';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
+import { IngredientRequirementDto } from '@app/recipe/dto/recipe/ingredient-requirement.dto';
+import { RecipeStepDto } from '@app/recipe/dto/recipe/recipe-step.dto';
 
-export class UpdateMongoRecipeDto extends PartialType(
-  OmitType(CreateMongoRecipeDto, ['ownerId'] as const),
-) {
+export class UpdateMongoRecipeDto {
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  name?: string;
+
+  @ApiExpose({ name: 'mysql_id', isOptional: true })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  mysqlId?: number;
+
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  description?: string;
+
+  @ApiExpose({ name: 'owner_id', isOptional: true })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  ownerId?: number;
+
+  @ApiExpose({ name: 'ingredient_requirements', isOptional: true })
+  @ValidateNested()
+  @ArrayNotEmpty()
+  @IsOptional()
+  @IsArray()
+  ingredientRequirements?: IngredientRequirementDto[];
+
+  @ApiExpose({ name: 'recipe_steps', isOptional: true })
+  @ValidateNested()
+  @ArrayNotEmpty()
+  @IsOptional()
+  @IsArray()
+  recipeSteps?: RecipeStepDto[];
+
+  @IsUrl()
+  @IsOptional()
+  @IsString()
+  thumbnail?: string;
+
+  @ApiExpose({ name: 'recipe_raw_text', isOptional: true })
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  recipeRawText?: string;
+
+  @ApiExpose({ name: 'origin_url', isOptional: true })
+  @IsUrl()
+  @IsOptional()
+  @IsString()
+  originUrl?: string;
+
   @ApiExpose({ name: 'view_count', isOptional: true })
   @IsOptional()
   @IsInt()
   viewCount?: number;
-
-  @ApiExpose({ name: 'mysql_id', isOptional: true })
-  @IsOptional()
-  @IsInt()
-  mysqlId?: number;
 }

--- a/api/libs/recipe/src/dto/recipe/update-recipe.dto.ts
+++ b/api/libs/recipe/src/dto/recipe/update-recipe.dto.ts
@@ -1,23 +1,46 @@
 import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateRecipeDto } from './create-recipe.dto';
-import { IsDate, IsInt, IsMongoId, IsOptional } from 'class-validator';
+import {
+  IsInt,
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+} from 'class-validator';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 
 export class UpdateRecipeDto extends PartialType(
   OmitType(CreateRecipeDto, ['ownerId'] as const),
 ) {
-  @ApiExpose({ name: 'view_count', isOptional: true })
+  @IsString()
   @IsOptional()
-  @IsInt()
-  viewCount?: number;
+  @IsNotEmpty()
+  name?: string;
 
   @ApiExpose({ name: 'mongo_id', isOptional: true })
   @IsOptional()
   @IsMongoId()
   mongoId?: string;
 
-  @ApiExpose({ name: 'created_at', isOptional: true })
+  @IsString()
   @IsOptional()
-  @IsDate()
-  createdAt?: Date;
+  @IsNotEmpty()
+  description?: string;
+
+  @IsUrl()
+  @IsOptional()
+  @IsString()
+  thumbnail?: string;
+
+  @ApiExpose({ name: 'origin_url ', isOptional: true })
+  @IsUrl()
+  @IsOptional()
+  @IsString()
+  originUrl?: string;
+
+  @ApiExpose({ name: 'view_count', isOptional: true })
+  @IsOptional()
+  @IsInt()
+  viewCount?: number;
 }

--- a/api/libs/recipe/src/exception/domain.exception.ts
+++ b/api/libs/recipe/src/exception/domain.exception.ts
@@ -1,0 +1,13 @@
+import { DomainException } from '@app/common/exception-filters/exception';
+
+export class RecipeNotExistsException extends DomainException {
+  message = 'Recipe not exists';
+}
+
+export class UserNotExistsException extends DomainException {
+  message = 'User not exists';
+}
+
+export class RecipeBookmarkDuplicateException extends DomainException {
+  message = 'Recipe bookmark already exists';
+}

--- a/api/libs/recipe/src/recipe.module.ts
+++ b/api/libs/recipe/src/recipe.module.ts
@@ -12,6 +12,7 @@ import { RecipeBookmarkRepository } from './repositories/recipe-bookmark/recipe-
 import { RecipeViewLogRepository } from './repositories/recipe-view-log/recipe-view-log.repository';
 import { MongoRecipeRepository } from './repositories/recipe/mongo.recipe.repository';
 import { RecipeRepository as PrismaRecipeRepository } from './repositories/recipe/recipe.repository';
+import { UserModule } from '@app/user/user.module';
 
 const PrismaRecipeRepositoryProvider: Provider = {
   provide: 'PrismaRecipeRepository',
@@ -34,6 +35,7 @@ const MongoRecipeRepositoryProvider: Provider = {
         },
       },
     ]),
+    UserModule,
   ],
   controllers: [RecipeController, RecipeBookmarkController],
   providers: [

--- a/api/libs/recipe/src/repositories/recipe-bookmark/recipe-bookmark.interface.ts
+++ b/api/libs/recipe/src/repositories/recipe-bookmark/recipe-bookmark.interface.ts
@@ -1,5 +1,5 @@
 import { ICrudRepository } from '@app/common/repository/crud.repository';
-import { RecipeBookmark as PrismaRecipeBookmark } from '@app/recipe/domain/recipe-bookmark.entity';
+import { RecipeBookmarkEntity as PrismaRecipeBookmark } from '@app/recipe/domain/recipe-bookmark.entity';
 import { RecipeBookmark as MongoRecipeBookmark } from '@app/recipe/domain/mongo/mongo.recipe-bookmark.entity';
 import { CreateRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/create-recipe-bookmark.dto';
 import { FilterRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/filter-recipe-bookmark.dto';

--- a/api/libs/recipe/src/repositories/recipe-bookmark/recipe-bookmark.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe-bookmark/recipe-bookmark.repository.ts
@@ -4,36 +4,26 @@ import { FilterRecipeBookmarkDto } from '../../dto/recipe-bookmark/filter-recipe
 import { deleteProps } from '@app/common/utils/delete-props';
 import { IRecipeBookmarkRepository } from './recipe-bookmark.interface';
 import { RecipeBookmarksAndCountDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmarks-count.dto';
-import { CreateRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/create-recipe-bookmark.dto';
-import { RecipeBookmark } from '@app/recipe/domain/recipe-bookmark.entity';
+import { RecipeBookmarkEntity } from '@app/recipe/domain/recipe-bookmark.entity';
 
 @Injectable()
 export class RecipeBookmarkRepository implements IRecipeBookmarkRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(createDto: CreateRecipeBookmarkDto) {
-    const ret = await this.prisma.recipeBookmark.create({
-      data: createDto,
-    });
-    return new RecipeBookmark({
-      id: ret.id,
-      recipeId: ret.recipeId,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
+  async create(entity: RecipeBookmarkEntity): Promise<RecipeBookmarkEntity> {
+    return await this.prisma.recipeBookmark.create({
+      data: {
+        recipeId: entity.recipeId,
+        userId: entity.userId,
+        createdAt: entity.createdAt,
+        updatedAt: entity.updatedAt,
+      },
     });
   }
 
-  async findOne(id: number) {
-    const ret = await this.prisma.recipeBookmark.findUnique({
+  async findOne(id: number): Promise<RecipeBookmarkEntity> {
+    return await this.prisma.recipeBookmark.findUnique({
       where: { id },
-    });
-    return new RecipeBookmark({
-      id: ret.id,
-      recipeId: ret.recipeId,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 
@@ -78,24 +68,28 @@ export class RecipeBookmarkRepository implements IRecipeBookmarkRepository {
     );
   }
 
-  async findAll(): Promise<RecipeBookmark[]> {
-    throw new Error('Method not implemented.');
-  }
-
-  async update(id: number, updateDto: any): Promise<RecipeBookmark> {
-    throw new Error('Method not implemented.');
-  }
-
-  async deleteOne(id: number) {
-    const ret = await this.prisma.recipeBookmark.delete({
-      where: { id },
+  async findAllByCond(
+    filterDto: FilterRecipeBookmarkDto,
+  ): Promise<RecipeBookmarkEntity[]> {
+    return await this.prisma.recipeBookmark.findMany({
+      where: {
+        userId: filterDto.userId,
+        recipeId: filterDto.recipeId,
+      },
     });
-    return new RecipeBookmark({
-      id: ret.id,
-      recipeId: ret.recipeId,
-      userId: ret.userId,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
+  }
+
+  async findAll(): Promise<RecipeBookmarkEntity[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  async update(id: number, updateDto: any): Promise<RecipeBookmarkEntity> {
+    throw new Error('Method not implemented.');
+  }
+
+  async deleteOne(id: number): Promise<RecipeBookmarkEntity> {
+    return await this.prisma.recipeBookmark.delete({
+      where: { id },
     });
   }
 }

--- a/api/libs/recipe/src/repositories/recipe-view-log/recipe-view-log.repository.interface.ts
+++ b/api/libs/recipe/src/repositories/recipe-view-log/recipe-view-log.repository.interface.ts
@@ -1,6 +1,6 @@
 import { ICrudRepository } from '@app/common/repository/crud.repository';
 import { RecipeViewLog as MongoRecipeViewLog } from '@app/recipe/domain/mongo/mongo.recipe-view-log.entity';
-import { RecipeViewLog as PrismaRecipeViewLog } from '@app/recipe/domain/recipe-view-log.entity';
+import { RecipeViewLogEntity as PrismaRecipeViewLog } from '@app/recipe/domain/recipe-view-log.entity';
 import { CreateRecipeViewLogDto } from '@app/recipe/dto/recipe-view-log/create-recipe-view-log.dto';
 
 import { RecipesItemDto } from '@app/recipe/dto/recipe/recipes-item.dto';

--- a/api/libs/recipe/src/repositories/recipe-view-log/recipe-view-log.repository.ts
+++ b/api/libs/recipe/src/repositories/recipe-view-log/recipe-view-log.repository.ts
@@ -1,5 +1,4 @@
-import { CreateRecipeViewLogDto } from '@app/recipe/dto/recipe-view-log/create-recipe-view-log.dto';
-import { RecipeViewLog } from '@app/recipe/domain/recipe-view-log.entity';
+import { RecipeViewLogEntity } from '@app/recipe/domain/recipe-view-log.entity';
 import { IRecipeViewLogRepository } from './recipe-view-log.repository.interface';
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { REDIS_PROVIDER } from '@app/common/redis.module';
@@ -20,45 +19,33 @@ export class RecipeViewLogRepository implements IRecipeViewLogRepository {
     private readonly recipeRepository: RecipeRepository,
   ) {}
 
-  async create(
-    createRecipeViewLogDto: CreateRecipeViewLogDto,
-  ): Promise<RecipeViewLog> {
+  async create(entity: RecipeViewLogEntity): Promise<RecipeViewLogEntity> {
     const createdEntity = this.prisma.recipeViewLog.create({
-      data: createRecipeViewLogDto,
+      data: {
+        recipeId: entity.recipeId,
+        userId: entity.userId,
+        userIp: entity.userIp,
+        createdAt: entity.createdAt,
+        updatedAt: entity.updatedAt,
+      },
     });
-    const result = (
+    return (
       await Promise.all([
         createdEntity,
         this.redisClient.zIncrBy(
           'recipe-view-count',
           1,
-          createRecipeViewLogDto.recipeId.toString(),
+          entity.recipeId.toString(),
         ),
       ])
     )[0];
-    return new RecipeViewLog({
-      id: result.id,
-      recipeId: result.recipeId,
-      userId: result.userId,
-      userIp: result.userIp,
-      createdAt: result.createdAt,
-      updatedAt: result.updatedAt,
-    });
   }
 
-  async findOne(id: number): Promise<RecipeViewLog> {
-    const ret = await await this.prisma.recipeViewLog.findUnique({
+  async findOne(id: number): Promise<RecipeViewLogEntity> {
+    return await await this.prisma.recipeViewLog.findUnique({
       where: {
         id,
       },
-    });
-    return new RecipeViewLog({
-      id: ret.id,
-      recipeId: ret.recipeId,
-      userId: ret.userId,
-      userIp: ret.userIp,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 
@@ -198,25 +185,15 @@ export class RecipeViewLogRepository implements IRecipeViewLogRepository {
     );
   }
 
-  async findAll(): Promise<RecipeViewLog[]> {
-    const ret = await this.prisma.recipeViewLog.findMany();
-    return ret.map((recipeViewLog) => {
-      return new RecipeViewLog({
-        id: recipeViewLog.id,
-        recipeId: recipeViewLog.recipeId,
-        userId: recipeViewLog.userId,
-        userIp: recipeViewLog.userIp,
-        createdAt: recipeViewLog.createdAt,
-        updatedAt: recipeViewLog.updatedAt,
-      });
-    });
+  async findAll(): Promise<RecipeViewLogEntity[]> {
+    return await this.prisma.recipeViewLog.findMany();
   }
 
-  async update(id: number, updateDto: any): Promise<RecipeViewLog> {
+  async update(id: number, updateDto: any): Promise<RecipeViewLogEntity> {
     throw new Error('Method not implemented.');
   }
 
-  async deleteOne(id: number): Promise<RecipeViewLog> {
+  async deleteOne(id: number): Promise<RecipeViewLogEntity> {
     throw new Error('Method not implemented.');
   }
 }

--- a/api/libs/recipe/src/repositories/recipe/recipe.repository.interface.ts
+++ b/api/libs/recipe/src/repositories/recipe/recipe.repository.interface.ts
@@ -1,7 +1,6 @@
-import { Recipe as PrismaRecipe } from '@app/recipe/domain/recipe.entity';
+import { RecipeEntity as PrismaRecipe } from '@app/recipe/domain/recipe.entity';
 import { Recipe as MongoRecipe } from '@app/recipe/domain/mongo/mongo.recipe.entity';
 import { ICrudRepository } from '@app/common/repository/crud.repository';
-import { FilterRecipeDto } from '../../dto/recipe/filter-recipe.dto';
 import { CreateRecipeDto } from '@app/recipe/dto/recipe/create-recipe.dto';
 import { UpdateRecipeDto } from '@app/recipe/dto/recipe/update-recipe.dto';
 import { TextSearchRecipeDto } from '@app/recipe/dto/recipe/text-search.dto';

--- a/api/libs/recipe/src/services/recipe-bookmark.service.ts
+++ b/api/libs/recipe/src/services/recipe-bookmark.service.ts
@@ -1,33 +1,59 @@
-import { CrudService } from '@app/common/crud.service';
 import { FilterRecipeBookmarkDto } from '../dto/recipe-bookmark/filter-recipe-bookmark.dto';
-import { CreateRecipeBookmarkDto } from '../dto/recipe-bookmark/create-recipe-bookmark.dto';
 import { RecipeBookmarkRepository } from '../repositories/recipe-bookmark/recipe-bookmark.repository';
-import { Injectable } from '@nestjs/common';
-import { RecipeBookmark } from '@app/recipe/domain/recipe-bookmark.entity';
+import { Inject, Injectable } from '@nestjs/common';
 import { Logable } from '@app/common/log/log.decorator';
-import { RecipesResponseDto } from '@app/recipe/dto/recipe/recipes-response.dto';
+import { CreateRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/create-recipe-bookmark.dto';
+import { RecipeRepository } from '@app/recipe/repositories/recipe/recipe.repository';
+import { UserRepository } from '@app/user/repositories/user.repository';
+import {
+  RecipeBookmark,
+  RecipeBookmarkEntity,
+} from '@app/recipe/domain/recipe-bookmark.entity';
+import { RecipeBookmarkDuplicateException } from '@app/recipe/exception/domain.exception';
+import { RecipeBookmarksResponseDto } from '@app/recipe/dto/recipe-bookmark/recipe-bookmarks-response.dto';
 
 @Injectable()
-export class RecipeBookmarkService extends CrudService<
-  RecipeBookmark,
-  CreateRecipeBookmarkDto,
-  any
-> {
+export class RecipeBookmarkService {
   constructor(
     private readonly recipeBookmarkRespository: RecipeBookmarkRepository,
-  ) {
-    super(recipeBookmarkRespository);
+    @Inject('PrismaRecipeRepository')
+    private readonly recipeRepository: RecipeRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async create(dto: CreateRecipeBookmarkDto) {
+    const [bookmarkDuplicate, recipe, user] = await Promise.all([
+      this.recipeBookmarkRespository.findAllByCond({
+        userId: dto.userId,
+        recipeId: dto.recipeId,
+        page: 1,
+        limit: 1,
+      }),
+      this.recipeRepository.findOne(dto.recipeId),
+      this.userRepository.findOne(dto.userId),
+    ]);
+    if (bookmarkDuplicate.length > 0) {
+      throw new RecipeBookmarkDuplicateException();
+    }
+    const recipeBookmark = RecipeBookmark.create(dto, recipe, user, new Date());
+    return await this.recipeBookmarkRespository.create(
+      RecipeBookmarkEntity.from(recipeBookmark),
+    );
   }
 
   @Logable()
   async findAllRecipeBookmarked(
     filterRecipeBookmarkDto: FilterRecipeBookmarkDto,
-  ): Promise<RecipesResponseDto> {
+  ): Promise<RecipeBookmarksResponseDto> {
     const { page, limit } = filterRecipeBookmarkDto;
     return (
       await this.recipeBookmarkRespository.findAllRecipeBookmarked(
         filterRecipeBookmarkDto,
       )
     ).toRecipeBookmarksResponseDto(page, limit);
+  }
+
+  async deleteOne(id: number) {
+    await this.recipeBookmarkRespository.deleteOne(id);
   }
 }

--- a/api/libs/recipe/test/unit/recipe-bookmark.spec.ts
+++ b/api/libs/recipe/test/unit/recipe-bookmark.spec.ts
@@ -1,0 +1,79 @@
+import { CreateRecipeBookmarkDto } from '@app/recipe/dto/recipe-bookmark/create-recipe-bookmark.dto';
+import { RecipeEntity } from '@app/recipe/domain/recipe.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
+import { Diet } from '@prisma/client';
+import { RecipeBookmark } from '@app/recipe/domain/recipe-bookmark.entity';
+import {
+  RecipeNotExistsException,
+  UserNotExistsException,
+} from '@app/recipe/exception/domain.exception';
+
+describe('RecipeBookmark', () => {
+  describe('create', () => {
+    const createRecipeBookmarkDto: CreateRecipeBookmarkDto = {
+      recipeId: 1,
+      userId: 1,
+    };
+    const recipeEntity: RecipeEntity = new RecipeEntity({
+      id: 1,
+      mongoId: null,
+      name: 'recipe-name',
+      description: 'recipe-description',
+      ownerId: 1,
+      owner: null,
+      thumbnail: 'recipe-thumbnail',
+      originUrl: 'recipe-origin-url',
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const userEntity: UserEntity = new UserEntity({
+      id: 1,
+      email: 'user-email',
+      username: 'user-name',
+      introduction: 'user-introduction',
+      diet: Diet.NORMAL,
+      thumbnail: 'user-thumbnail',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const datetime = new Date();
+
+    it('create instance with valid data', () => {
+      const recipeBookmark = RecipeBookmark.create(
+        createRecipeBookmarkDto,
+        recipeEntity,
+        userEntity,
+        datetime,
+      );
+
+      expect(recipeBookmark).toBeDefined();
+    });
+
+    it('should not create if recipe is not exists', () => {
+      const recipeEntity: RecipeEntity = null;
+
+      expect(() =>
+        RecipeBookmark.create(
+          createRecipeBookmarkDto,
+          recipeEntity,
+          userEntity,
+          datetime,
+        ),
+      ).toThrow(RecipeNotExistsException);
+    });
+
+    it('should not create if user is not exists', () => {
+      const userEntity: UserEntity = null;
+
+      expect(() =>
+        RecipeBookmark.create(
+          createRecipeBookmarkDto,
+          recipeEntity,
+          userEntity,
+          datetime,
+        ),
+      ).toThrow(UserNotExistsException);
+    });
+  });
+});

--- a/api/libs/recipe/test/unit/recipe-view-log.spec.ts
+++ b/api/libs/recipe/test/unit/recipe-view-log.spec.ts
@@ -1,0 +1,84 @@
+import { CreateRecipeViewLogDto } from '@app/recipe/dto/recipe-view-log/create-recipe-view-log.dto';
+import { RecipeEntity } from '@app/recipe/domain/recipe.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
+import { RecipeViewLog } from '@app/recipe/domain/recipe-view-log.entity';
+import {
+  RecipeNotExistsException,
+  UserNotExistsException,
+} from '@app/recipe/exception/domain.exception';
+
+describe('RecipeViewLog', () => {
+  describe('create', () => {
+    const createRecipeViewLogDto: CreateRecipeViewLogDto = {
+      recipeId: 1,
+      userId: 1,
+      userIp: ':::1',
+    };
+    const recipeEntity: RecipeEntity = {
+      id: 1,
+      mongoId: null,
+      name: 'recipe-name',
+      description: 'recipe-description',
+      ownerId: 1,
+      owner: null,
+      thumbnail: 'recipe-thumbnail',
+      originUrl: 'recipe-origin-url',
+      viewCount: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const userEntity: UserEntity = {
+      id: 1,
+      email: 'user-email',
+      username: 'user-name',
+      introduction: 'user-introduction',
+      diet: 'NORMAL',
+      thumbnail: 'user-thumbnail',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const datetime = new Date();
+
+    it('create instance with valid data', () => {
+      const recipeViewLog = RecipeViewLog.create(
+        createRecipeViewLogDto,
+        recipeEntity,
+        userEntity,
+        datetime,
+      );
+
+      expect(recipeViewLog).toBeDefined();
+    });
+
+    it('should not create if recipe is not exists', () => {
+      const recipeEntity: RecipeEntity = null;
+
+      expect(() =>
+        RecipeViewLog.create(
+          createRecipeViewLogDto,
+          recipeEntity,
+          userEntity,
+          datetime,
+        ),
+      ).toThrow(RecipeNotExistsException);
+    });
+
+    it('should not create if either user or userIp is not exists', () => {
+      const userEntity: UserEntity = null;
+      const createRecipeViewLogDto: CreateRecipeViewLogDto = {
+        recipeId: 1,
+        userId: null,
+        userIp: null,
+      };
+
+      expect(() =>
+        RecipeViewLog.create(
+          createRecipeViewLogDto,
+          recipeEntity,
+          userEntity,
+          datetime,
+        ),
+      ).toThrow(UserNotExistsException);
+    });
+  });
+});

--- a/api/libs/recipe/test/unit/recipe.service.spec.ts
+++ b/api/libs/recipe/test/unit/recipe.service.spec.ts
@@ -4,9 +4,9 @@ import { RecipeRepository } from '@app/recipe/repositories/recipe/recipe.reposit
 import { RecipeService } from '@app/recipe/services/recipe.service';
 import { TestBed } from '@automock/jest';
 import { RecipeViewLogRepository } from '@app/recipe/repositories/recipe-view-log/recipe-view-log.repository';
-import { RecipeViewLog } from '@app/recipe/domain/recipe-view-log.entity';
-import { User } from '@app/user/domain/user.entity';
-import { Recipe } from '@app/recipe/domain/recipe.entity';
+import { RecipeViewLogEntity } from '@app/recipe/domain/recipe-view-log.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
+import { RecipeEntity } from '@app/recipe/domain/recipe.entity';
 import { Recipe as MongoRecipe } from '@app/recipe/domain/mongo/mongo.recipe.entity';
 import { RecipeViewerIdentifier } from '@app/recipe/dto/recipe-view-log/recipe-viewer-identifier';
 import { Types } from 'mongoose';
@@ -17,7 +17,7 @@ import { RecipeDetailDto } from '@app/recipe/dto/recipe/recipe-detail.dto';
 import { RecipesItemDto } from '@app/recipe/dto/recipe/recipes-item.dto';
 import { RecipesResponseDto } from '@app/recipe/dto/recipe/recipes-response.dto';
 import { RecipesAndCountDto } from '@app/recipe/dto/recipe/recipes-count.dto';
-import { Diet } from '@app/user/domain/diet.enum';
+import { Diet } from '@prisma/client';
 
 describe('RecipeService', () => {
   let service: RecipeService;
@@ -56,7 +56,7 @@ describe('RecipeService', () => {
     count: 2,
     hasNext: false,
   };
-  const user = new User({
+  const user: UserEntity = {
     id: 1,
     email: 'test@test.com',
     username: 'test',
@@ -65,8 +65,8 @@ describe('RecipeService', () => {
     thumbnail: '',
     createdAt: new Date(),
     updatedAt: new Date(),
-  });
-  const recipe = new Recipe({
+  };
+  const recipe: RecipeEntity = {
     id: 1,
     name: 'test',
     mongoId: 'test',
@@ -78,8 +78,8 @@ describe('RecipeService', () => {
     viewCount: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
-  });
-  const recipeViewLog = new RecipeViewLog({
+  };
+  const recipeViewLog: RecipeViewLogEntity = {
     id: 1,
     recipeId: recipe.id,
     recipe,
@@ -88,7 +88,7 @@ describe('RecipeService', () => {
     userIp: '::1',
     createdAt: new Date(),
     updatedAt: new Date(),
-  });
+  };
 
   beforeEach(async () => {
     const { unit, unitRef } = TestBed.create(RecipeService).compile();
@@ -131,14 +131,14 @@ describe('RecipeService', () => {
 
   describe('findAll', () => {
     it('should return an array of recipes with last elements', async () => {
-      recipeRepository.findAllRecipe.mockResolvedValue(recipesAndCountLast);
+      recipeRepository.findAllByCond.mockResolvedValue(recipesAndCountLast);
       recipesAndCountLast.toRecipesResponseDto.mockReturnValue(
         recipesResponseDtoLast,
       );
 
       const result = await service.findAll(filterRecipeDto);
 
-      expect(recipeRepository.findAllRecipe).toHaveBeenCalledWith(
+      expect(recipeRepository.findAllByCond).toHaveBeenCalledWith(
         filterRecipeDto,
       );
       expect(recipesAndCountLast.toRecipesResponseDto).toHaveBeenCalledWith(
@@ -149,14 +149,14 @@ describe('RecipeService', () => {
     });
 
     it('should return an array of recipes with not finished', async () => {
-      recipeRepository.findAllRecipe.mockResolvedValue(recipesAndCountNotLast);
+      recipeRepository.findAllByCond.mockResolvedValue(recipesAndCountNotLast);
       recipesAndCountNotLast.toRecipesResponseDto.mockReturnValue(
         recipesResponseDtoNotLast,
       );
 
       const result = await service.findAll(filterRecipeDto);
 
-      expect(recipeRepository.findAllRecipe).toHaveBeenCalledWith(
+      expect(recipeRepository.findAllByCond).toHaveBeenCalledWith(
         filterRecipeDto,
       );
       expect(recipesAndCountNotLast.toRecipesResponseDto).toHaveBeenCalledWith(
@@ -169,14 +169,14 @@ describe('RecipeService', () => {
 
   describe('findAllByFullTextSearch', () => {
     it('should return an last element array of recipes without search query', async () => {
-      recipeRepository.findAllRecipe.mockResolvedValue(recipesAndCountLast);
+      recipeRepository.findAllByCond.mockResolvedValue(recipesAndCountLast);
       recipesAndCountLast.toRecipesResponseDto.mockReturnValue(
         recipesResponseDtoLast,
       );
 
       const result = await service.findAllByFullTextSearch(filterRecipeDto);
 
-      expect(recipeRepository.findAllRecipe).toHaveBeenCalledWith(
+      expect(recipeRepository.findAllByCond).toHaveBeenCalledWith(
         filterRecipeDto,
       );
       expect(
@@ -202,7 +202,7 @@ describe('RecipeService', () => {
       expect(
         mongoRecipeRepository.findAllByFullTextSearch,
       ).toHaveBeenCalledWith(textSearchRecipeDto);
-      expect(recipeRepository.findAllRecipe).not.toHaveBeenCalled();
+      expect(recipeRepository.findAllByCond).not.toHaveBeenCalled();
       expect(recipesAndCountLast.toRecipesResponseDto).toHaveBeenCalledWith(
         textSearchRecipeDto.page,
         textSearchRecipeDto.limit,
@@ -211,14 +211,14 @@ describe('RecipeService', () => {
     });
 
     it('should return an middle elements array of recipes without search query', async () => {
-      recipeRepository.findAllRecipe.mockResolvedValue(recipesAndCountNotLast);
+      recipeRepository.findAllByCond.mockResolvedValue(recipesAndCountNotLast);
       recipesAndCountNotLast.toRecipesResponseDto.mockReturnValue(
         recipesResponseDtoNotLast,
       );
 
       const result = await service.findAllByFullTextSearch(filterRecipeDto);
 
-      expect(recipeRepository.findAllRecipe).toHaveBeenCalledWith(
+      expect(recipeRepository.findAllByCond).toHaveBeenCalledWith(
         filterRecipeDto,
       );
       expect(recipeRepository.findAllByFullTextSearch).not.toHaveBeenCalled();
@@ -242,7 +242,7 @@ describe('RecipeService', () => {
       expect(
         mongoRecipeRepository.findAllByFullTextSearch,
       ).toHaveBeenCalledWith(textSearchRecipeDto);
-      expect(recipeRepository.findAllRecipe).not.toHaveBeenCalled();
+      expect(recipeRepository.findAllByCond).not.toHaveBeenCalled();
       expect(recipesAndCountNotLast.toRecipesResponseDto).toHaveBeenCalledWith(
         textSearchRecipeDto.page,
         textSearchRecipeDto.limit,
@@ -263,7 +263,7 @@ describe('RecipeService', () => {
 
       const result = await service.findOne(1, {
         ip: '::1',
-        user: new User({
+        user: new UserEntity({
           id: 1,
           email: 'test@test.com',
           username: 'test',
@@ -275,13 +275,6 @@ describe('RecipeService', () => {
         }),
       });
 
-      expect(recipeRepository.increaseViewCount).toHaveBeenCalledWith(1);
-      expect(recipeViewLogRepository.create).toHaveBeenCalledWith({
-        recipeId: 1,
-        userId: 1,
-        userIp: '::1',
-      });
-      expect(mongoRecipeRepository.findOneByMysqlId).toHaveBeenCalledWith(1);
       expect(result).toEqual(recipeDto);
     });
   });
@@ -314,7 +307,7 @@ describe('RecipeService', () => {
       const result = await service.findAllRecentViewed(
         filterRecipeDto,
         new RecipeViewerIdentifier(
-          new User({
+          new UserEntity({
             id: 1,
             email: 'test@test.com',
             username: 'test',
@@ -350,7 +343,7 @@ describe('RecipeService', () => {
       const result = await service.findAllRecentViewed(
         filterRecipeDto,
         new RecipeViewerIdentifier(
-          new User({
+          new UserEntity({
             id: 1,
             email: 'test@test.com',
             username: 'test',
@@ -377,7 +370,7 @@ describe('RecipeService', () => {
   });
 
   describe('viewRecipe', () => {
-    it('should return true', async () => {
+    it('should return true and create RecipeViewLog', async () => {
       recipeRepository.increaseViewCount.mockResolvedValue(recipe);
       mongoRecipeRepository.increaseViewCountByMySqlId.mockResolvedValue(
         new MongoRecipe(),
@@ -386,7 +379,7 @@ describe('RecipeService', () => {
 
       const result = await service.viewRecipe(1, {
         ip: '::1',
-        user: new User({
+        user: new UserEntity({
           id: 1,
           email: 'test@test.com',
           username: 'test',
@@ -398,23 +391,17 @@ describe('RecipeService', () => {
         }),
       });
 
-      expect(recipeRepository.increaseViewCount).toHaveBeenCalledWith(1);
-      expect(recipeViewLogRepository.create).toHaveBeenCalledWith({
-        recipeId: 1,
-        userId: 1,
-        userIp: '::1',
-      });
       expect(result).toEqual(true);
     });
 
-    it('should throw NotFoundException', async () => {
+    it('should not create RecipeViewLog', async () => {
       recipeRepository.increaseViewCount.mockResolvedValue(null);
       mongoRecipeRepository.increaseViewCountByMySqlId.mockResolvedValue(null);
 
       await expect(
         service.viewRecipe(1, {
           ip: '::1',
-          user: new User({
+          user: new UserEntity({
             id: 1,
             email: 'test@test.com',
             username: 'test',
@@ -425,7 +412,7 @@ describe('RecipeService', () => {
             updatedAt: new Date(),
           }),
         }),
-      ).rejects.toThrowError('Recipe not found');
+      ).rejects.toThrowError();
     });
   });
 

--- a/api/libs/user/src/domain/user.entity.ts
+++ b/api/libs/user/src/domain/user.entity.ts
@@ -1,4 +1,50 @@
 import { Diet } from '@app/user/domain/diet.enum';
+import { $Enums, User as UserType } from '@prisma/client';
+import { CreateUserDto } from '@app/user/dto/modify-user.dto';
+
+export class UserEntity implements UserType {
+  public readonly id: number;
+  public readonly username: string;
+  public readonly email: string;
+  public readonly introduction: string;
+  public readonly diet: $Enums.Diet;
+  public readonly thumbnail: string;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
+
+  constructor(props: {
+    id: number;
+    username: string;
+    email: string;
+    introduction: string;
+    diet: $Enums.Diet;
+    thumbnail: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    this.id = props.id;
+    this.username = props.username;
+    this.email = props.email;
+    this.introduction = props.introduction;
+    this.diet = props.diet;
+    this.thumbnail = props.thumbnail;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
+  }
+
+  static from(user: User) {
+    return new UserEntity({
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      introduction: user.introduction,
+      diet: $Enums.Diet[user.diet],
+      thumbnail: user.thumbnail,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    });
+  }
+}
 
 export class User {
   constructor(props: {
@@ -67,5 +113,18 @@ export class User {
 
   get updatedAt(): Date {
     return this._updatedAt;
+  }
+
+  static create(dto: CreateUserDto, datetime: Date) {
+    return new User({
+      id: null,
+      username: dto.username,
+      email: dto.email,
+      introduction: '자기소개입니다.',
+      diet: Diet.NORMAL,
+      thumbnail: dto.thumbnail,
+      createdAt: datetime,
+      updatedAt: datetime,
+    });
   }
 }

--- a/api/libs/user/src/dto/user.dto.ts
+++ b/api/libs/user/src/dto/user.dto.ts
@@ -1,4 +1,4 @@
-import { User } from '@app/user/domain/user.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
 import { ApiExpose } from '@app/common/decorators/api-expose.decorator';
 import { Diet } from '@app/user/domain/diet.enum';
 
@@ -43,7 +43,7 @@ export class UserDto {
     this.updatedAt = updatedAt;
   }
 
-  static from(user: User): UserDto {
+  static fromEntity(user: UserEntity): UserDto {
     return new UserDto(
       user.id,
       user.username,

--- a/api/libs/user/src/exception/domain.exception.ts
+++ b/api/libs/user/src/exception/domain.exception.ts
@@ -1,0 +1,9 @@
+import { DomainException } from '@app/common/exception-filters/exception';
+
+export class UserEmailDuplicateException extends DomainException {
+  message = 'User email already exists';
+}
+
+export class UserNameDuplicateException extends DomainException {
+  message = 'User username already exists';
+}

--- a/api/libs/user/src/repositories/user.repository.interface.ts
+++ b/api/libs/user/src/repositories/user.repository.interface.ts
@@ -1,6 +1,6 @@
 import { ICrudRepository } from '@app/common/repository/crud.repository';
 import { User as MongoUser } from '@app/user/domain/mongo.user.entity';
-import { User as PrismaUser } from '@app/user/domain/user.entity';
+import { UserEntity as PrismaUser } from '@app/user/domain/user.entity';
 import { CreateUserDto, UpdateUserDto } from '../dto/modify-user.dto';
 
 type User = MongoUser | PrismaUser;

--- a/api/libs/user/src/repositories/user.repository.ts
+++ b/api/libs/user/src/repositories/user.repository.ts
@@ -1,29 +1,27 @@
 import { PrismaService } from '@app/common/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
 import { IUserRepository } from './user.repository.interface';
-import { User } from '@app/user/domain/user.entity';
+import { UserEntity } from '@app/user/domain/user.entity';
 import { Logable } from '@app/common/log/log.decorator';
 import { Cacheable } from '@app/common/cache/cache.service';
-import { CreateUserDto, UpdateUserDto } from '@app/user/dto/modify-user.dto';
+import { UpdateUserDto } from '@app/user/dto/modify-user.dto';
 import { Diet } from '@prisma/client';
 
 @Injectable()
 export class UserRepository implements IUserRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateUserDto) {
-    const ret = await this.prisma.user.create({
-      data: dto,
-    });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
+  async create(entity: UserEntity): Promise<UserEntity> {
+    return await this.prisma.user.create({
+      data: {
+        email: entity.email,
+        username: entity.username,
+        introduction: entity.introduction,
+        diet: Diet[entity.diet],
+        thumbnail: entity.thumbnail,
+        createdAt: entity.createdAt,
+        updatedAt: entity.updatedAt,
+      },
     });
   }
 
@@ -32,106 +30,43 @@ export class UserRepository implements IUserRepository {
     ttl: 60 * 1000,
     keyGenerator: (user: string) => `user:${user}`,
   })
-  async findOne(id: number) {
-    const ret = await this.prisma.user.findUnique({
+  async findOne(id: number): Promise<UserEntity> {
+    return await this.prisma.user.findUnique({
       where: { id },
     });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
-    });
   }
 
   @Logable()
-  async findByEmail(email: string): Promise<User> {
-    const ret = await this.prisma.user.findUnique({
+  async findByEmail(email: string): Promise<UserEntity> {
+    return await this.prisma.user.findUnique({
       where: { email },
     });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
-    });
   }
 
   @Logable()
-  async findByUsername(username: string): Promise<User> {
-    const ret = await this.prisma.user.findUnique({
+  async findByUsername(username: string): Promise<UserEntity> {
+    return await this.prisma.user.findUnique({
       where: { username },
     });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
-    });
   }
 
-  async findAll(): Promise<User[]> {
-    const ret = await this.prisma.user.findMany();
-    return ret.map(
-      (user) =>
-        new User({
-          id: user.id,
-          email: user.email,
-          username: user.username,
-          introduction: user.introduction,
-          diet: user.diet,
-          thumbnail: user.thumbnail,
-          createdAt: user.createdAt,
-          updatedAt: user.updatedAt,
-        }),
-    );
+  async findAll(): Promise<UserEntity[]> {
+    return await this.prisma.user.findMany();
   }
 
-  async update(id: number, dto: UpdateUserDto): Promise<User> {
-    const ret = await this.prisma.user.update({
+  async update(id: number, dto: UpdateUserDto): Promise<UserEntity> {
+    return await this.prisma.user.update({
       where: { id },
       data: {
         ...dto,
         diet: Diet[dto.diet],
       },
     });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
-    });
   }
 
-  async deleteOne(id: number): Promise<User> {
-    const ret = await this.prisma.user.delete({
+  async deleteOne(id: number): Promise<UserEntity> {
+    return await this.prisma.user.delete({
       where: { id },
-    });
-    return new User({
-      id: ret.id,
-      email: ret.email,
-      username: ret.username,
-      introduction: ret.introduction,
-      diet: ret.diet,
-      thumbnail: ret.thumbnail,
-      createdAt: ret.createdAt,
-      updatedAt: ret.updatedAt,
     });
   }
 }

--- a/api/libs/user/src/user.controller.ts
+++ b/api/libs/user/src/user.controller.ts
@@ -41,7 +41,7 @@ export class UserController {
   @Post()
   async create(@Body() createUserDto: CreateUserDto) {
     const user = await this.userService.create(createUserDto);
-    return UserDto.from(user);
+    return UserDto.fromEntity(user);
   }
 
   /**
@@ -54,7 +54,7 @@ export class UserController {
   @Get()
   async findAll() {
     const users = await this.userService.findAll();
-    return users.map((user) => UserDto.from(user));
+    return users.map((user) => UserDto.fromEntity(user));
   }
 
   /**
@@ -67,7 +67,7 @@ export class UserController {
   @Get(':id')
   async findOne(@Param('id', ParseIntPipe) id: number) {
     const user = await this.userService.findOne(id);
-    return UserDto.from(user);
+    return UserDto.fromEntity(user);
   }
 
   /**
@@ -83,7 +83,7 @@ export class UserController {
     @Body() updateUserDto: UpdateUserDto,
   ) {
     const user = await this.userService.update(id, updateUserDto);
-    return UserDto.from(user);
+    return UserDto.fromEntity(user);
   }
 
   /**
@@ -98,6 +98,6 @@ export class UserController {
   @Delete(':id')
   async delete(@Param('id', ParseIntPipe) id: number) {
     const user = await this.userService.deleteOne(id);
-    return UserDto.from(user);
+    return UserDto.fromEntity(user);
   }
 }

--- a/api/libs/user/src/user.module.ts
+++ b/api/libs/user/src/user.module.ts
@@ -31,6 +31,7 @@ import { ConfigService } from '@nestjs/config';
   ],
   exports: [
     UserService,
+    UserRepository,
     {
       provide: 'UserSchema',
       useValue: UserSchema,

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -50,7 +50,7 @@ model RecipeBookmark {
   id        Int      @id @default(autoincrement())
   userId    Int      @map("user_id")
   user      User     @relation(fields: [userId], references: [id])
-  recipeId  Int      @map("recipeId")
+  recipeId  Int      @map("recipe_id")
   recipe    Recipe   @relation(fields: [recipeId], references: [id])
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")


### PR DESCRIPTION
## Done

- close #113 
- Add domain object, add entity object for readonly
- Domain object would be a state storage and only-state-changeable object, so setters are not in domain object
- All domain/business logic which should change state would be evaluated and operated in domain object's public interface
- Add missing class-transformer serializer
- 
### TODO

- improve poor recipe creating logic
- add domain object's functionality to other domains(noti, ingredient, etc)

---

## Notice
